### PR TITLE
Removed 'docker-build' tag from viz service image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -511,7 +511,7 @@ services:
         }
 
   # viz:
-  #   image: tidepool/viz:docker-build
+  #   image: tidepool/viz
   #   volumes:
   #     - ${TIDEPOOL_DOCKER_VIZ_DIR}:/app:cached
   #     - /app/node_modules


### PR DESCRIPTION
What it says.  That tag doesn't exist on the `tidepool/viz` image