### PR TITLE
sh does not have shopt; use bash instead

### DIFF
--- a/bin/tidepool_docker
+++ b/bin/tidepool_docker
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/bash -eu
 shopt -s extglob
 
 DIR=$(cd $(dirname $(dirname ${0})); pwd)


### PR DESCRIPTION
What it says on the tin.