### PR TITLE
Frontend development volume fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,28 @@ docker-compose exec viz sh -c "yarn run stories"
 # Run the stories for diabetes data type visualizations on http://localhost:8082
 docker-compose exec viz sh -c "yarn run typestories"
 ```
+
+### Troubleshooting Webpack Dev Server issues in blip or viz with Docker For Mac
+
+From time to time, the Webpack Dev Server started by the `blip` or `viz` npm `start` scripts will stop detecting file changes, which will stop the live recompiling.  It is unclear why this occurs, but the following steps seem to fix it:
+
+Examples for `blip`.  Simply replace with `viz` as needed.
+
+```bash
+# First, try a simple restart of the service
+docker-compose restart blip
+
+# This will often do it.  If not, try bringing down the full stack and restarting
+docker-compose down
+docker-compose up
+
+# If this doesn't work, try restarting Docker For Mac and bring up the stack as per ussual.
+# On very rare occasions, there is a corrupted volume mount.
+# To fix this, remove the container and it's volumes, and restart the service
+docker-compose rm -fsv blip
+docker-compose up blip
+```
+
 # Tidepool Helper Script
 
 Included in the `bin` directory of this repo is a bash script named `tidepool_docker`.
@@ -705,6 +727,7 @@ The following commands are provided (note that some commands only apply to Node.
 | `up [service]`                | start and/or (re)build the entire tidepool stack or the specified service                                                                                           |
 | `down`                        | shut down and remove the entire tidepool stack                                                                                                                      |
 | `stop`                        | shut down the entire tidepool stack or the specified service                                                                                                        |
+| `rm [service]`                | stops and removes the all service containers or the specified service containers                                                                                    |
 | `restart [service]`           | restart the entire tidepool stack or the specified service                                                                                                          |
 | `pull [service]`              | pull the latest images for the entire tidepool stack or the specified service                                                                                       |
 | `logs [service]`              | tail logs for the entire tidepool stack or the specified service                                                                                                    |

--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ The following commands are provided (note that some commands only apply to Node.
 | `up [service]`                | start and/or (re)build the entire tidepool stack or the specified service                                                                                           |
 | `down`                        | shut down and remove the entire tidepool stack                                                                                                                      |
 | `stop`                        | shut down the entire tidepool stack or the specified service                                                                                                        |
-| `rm [service]`                | stops and removes the all service containers or the specified service containers                                                                                    |
+| `rm [service]`                | stops and removes containers and volumes for the entire tidepool stack or the specified service                                                                     |
 | `restart [service]`           | restart the entire tidepool stack or the specified service                                                                                                          |
 | `pull [service]`              | pull the latest images for the entire tidepool stack or the specified service                                                                                       |
 | `logs [service]`              | tail logs for the entire tidepool stack or the specified service                                                                                                    |

--- a/bin/tidepool_docker
+++ b/bin/tidepool_docker
@@ -12,7 +12,7 @@ USAGE: tidepool_docker command [service] [...additional args]
     up [service]                    start and/or (re)build the entire tidepool stack or the specified service
     down                            shut down and remove the entire tidepool stack
     stop [service]                  shut down the entire tidepool stack or the specified service
-    rm [service]                    stops and removes the all service containers or the specified service containers
+    rm [service]                    stops and removes containers and volumes for the entire tidepool stack or the specified service
     restart [service]               restart the entire tidepool stack or the specified service
     pull [service]                  pull the latest images for the entire tidepool stack or the specified service
     logs [service]                  tail logs for the entire tidepool stack or the specified service

--- a/bin/tidepool_docker
+++ b/bin/tidepool_docker
@@ -12,6 +12,7 @@ USAGE: tidepool_docker command [service] [...additional args]
     up [service]                    start and/or (re)build the entire tidepool stack or the specified service
     down                            shut down and remove the entire tidepool stack
     stop [service]                  shut down the entire tidepool stack or the specified service
+    rm [service]                    stops and removes the all service containers or the specified service containers
     restart [service]               restart the entire tidepool stack or the specified service
     pull [service]                  pull the latest images for the entire tidepool stack or the specified service
     logs [service]                  tail logs for the entire tidepool stack or the specified service
@@ -72,13 +73,14 @@ run_yarn() {
 }
 
 case ${1-help} in
-  up) (cd ${DIR} && docker-compose up -d ${2-});;
-  down) (cd ${DIR} && docker-compose down ${2-});;
+  up) (cd ${DIR} && docker-compose up -dV ${2-});;
+  down) (cd ${DIR} && docker-compose down -v);;
   stop) (cd ${DIR} && docker-compose stop ${2-});;
+  rm) (cd ${DIR} && docker-compose rm -fsv ${2-});;
   restart) restart ${2-};;
   pull) (cd ${DIR} && docker-compose pull ${2-});;
   logs) (cd ${DIR} && docker-compose logs --tail=20 -f ${2-});;
-  rebuild) (cd ${DIR} && docker-compose build ${2} && docker-compose up -d ${2-});;
+  rebuild) (cd ${DIR} && docker-compose build ${2-} && docker-compose up -d ${2-});;
   exec) run_exec ${2} ${@:3};;
   link) (cd ${DIR} && docker-compose exec ${2} /bin/sh -c "cd /${3} && yarn link && cd /app && yarn link ${3}") && restart ${2};;
   unlink) (cd ${DIR} && docker-compose exec ${2} /bin/sh -c "yarn unlink ${3}; cd /${3} && yarn unlink; cd /app && rm -f node_modules/${3} && yarn install --force") && restart ${2};;

--- a/bin/tidepool_docker
+++ b/bin/tidepool_docker
@@ -73,7 +73,7 @@ run_yarn() {
 }
 
 case ${1-help} in
-  up) (cd ${DIR} && docker-compose up -dV ${2-});;
+  up) (cd ${DIR} && docker-compose up -d ${2-});;
   down) (cd ${DIR} && docker-compose down -v);;
   stop) (cd ${DIR} && docker-compose stop ${2-});;
   rm) (cd ${DIR} && docker-compose rm -fsv ${2-});;


### PR DESCRIPTION
This PR provides some troubleshooting advice on how to handle hangups with the live recompiling of the `webpack-dev-server` processes started by the `blip` and `viz` run scripts.

It also includes the addition of a `tidepool_docker rm` command for the  to allow quick removal of the containers and volumes for a specified service.

One other small change is removing the volumes when running the `tidepool_docker down` command to ensure a clean slate.