### PR TITLE
Allow overriding the gateway and gateway-ssl default namespace [WEB-210]

### DIFF
--- a/charts/tidepool/0.1.7/templates/gateway-ssl.yaml
+++ b/charts/tidepool/0.1.7/templates/gateway-ssl.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     origin: default
   name: gateway-ssl
-  namespace: gloo-system
+  namespace: {{ .Values.ingress.deployment.namespace | default "gloo-system" }}
 spec:
   bindAddress: '::'
   bindPort: 8443

--- a/charts/tidepool/0.1.7/templates/gateway.yaml
+++ b/charts/tidepool/0.1.7/templates/gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     origin: default
   name: gateway
-  namespace: gloo-system
+  namespace: {{ .Values.ingress.deployment.namespace | default "gloo-system" }}
 spec:
   bindAddress: '::'
   bindPort: 8080


### PR DESCRIPTION
Fixes a Tilt K8s warning: `Error from server (NotFound): error when creating "STDIN": namespaces "gloo-system" not found`