### PR TITLE
Use local kubeconfig for remove_mesh

### DIFF
--- a/cmd/tpctl.sh
+++ b/cmd/tpctl.sh
@@ -762,6 +762,7 @@ function delete_cluster {
 
 # remove service mesh from cluster and config repo
 function remove_mesh {
+	export KUBECONFIG=$(realpath ./kubeconfig.yaml)
         start "removing linkerd"
         linkerd install --ignore-cluster | kubectl delete -f -
         rm -rf linkerd


### PR DESCRIPTION
The client kube config may not have use the new cluster.  So, instead, we use the kubeconfig file in the config repo, which only has the one cluster.