### PR TITLE
Allow specifying the webpack devtool sourcemap option for viz [WEB-210]

### DIFF
--- a/Tiltconfig.yaml
+++ b/Tiltconfig.yaml
@@ -110,6 +110,7 @@ blip:
   containerPath: '/app'
   apiHost: 'http://localhost:3000'
   webpackDevTool: cheap-module-eval-source-map
+  webpackDevToolViz: cheap-source-map # Suggest changing to the slower, but far more helpful `source-map` if debugging errors in viz package files
   webpackPublicPath: 'http://localhost:3000'
   disableDevTools: false # Suggest changing to `true` if working with large data sets in local development build
   linkedPackages:

--- a/charts/tidepool/0.1.7/charts/blip/templates/blip-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/blip/templates/blip-deployment.yaml
@@ -45,6 +45,10 @@ spec:
         - name: WEBPACK_DEVTOOL
           value: {{ .Values.webpackDevTool }}
 {{- end }}
+{{ if .Values.webpackDevToolViz }}
+        - name: WEBPACK_DEVTOOL_VIZ
+          value: {{ .Values.webpackDevToolViz }}
+{{- end }}
 {{ if .Values.disableDevTools }}
         - name: DEV_TOOLS
           value: 'false'


### PR DESCRIPTION
It's at times important to have `viz` compile with a more detailed source map for debugging (at the expense of slower compile times), which this PR enables via the Tiltconfic.yaml.

Part of [WEB-210] 

[WEB-210]: https://tidepool.atlassian.net/browse/WEB-210