### PR TITLE
Workaround K8s bug that prevents AWS EKS IAM for Service Accounts

### DIFF
--- a/bin/get_k8s_secret_from_aws
+++ b/bin/get_k8s_secret_from_aws
@@ -2,15 +2,15 @@
 #
 # Get Secret from AWS Secrets Manager
 #
-# Usage: $0 $SECRETID
+# Usage: $0 $CLUSTER $ENVIRONMENT $SECRET
 
-if [ $# -ne 1 ]
+if [ $# -ne 3 ]
 then
-	echo "Usage: $0 \$SECRETID, e.g. $0 development/qa1/mongo"
+	echo "Usage: $0 \$CLUSTER \$ENVIRONMENT \$SECRET  e.g. $0 development qa1 mongo"
 	exit 1
 fi
 
-yaml=$(aws secretsmanager get-secret-value  --secret-id $1 | jq '.SecretString | fromjson' | yq r - | sed -e 's/^/    /')
+yaml=$(aws secretsmanager get-secret-value  --secret-id $1/$2/$3 | jq '.SecretString | fromjson' | yq r - | sed -e 's/^/    /')
 
 cat <<!
 apiVersion: v1
@@ -19,6 +19,6 @@ type: Opaque
 data:
 $yaml
 metadata:
-  name: ${SECRET}
-  namespace: ${ENVIRONMENT}
+  name: $3
+  namespace: $2
 !

--- a/charts/tidepool/0.1.7/charts/auth/templates/auth-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/auth/templates/auth-deployment.yaml
@@ -93,6 +93,6 @@ spec:
         - containerPort: {{.Values.global.ports.auth}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 10 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/auth/templates/auth-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/auth/templates/auth-deployment.yaml
@@ -94,5 +94,5 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/blip/templates/blip-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/blip/templates/blip-deployment.yaml
@@ -65,6 +65,6 @@ spec:
 {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/blob/templates/blob-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/blob/templates/blob-deployment.yaml
@@ -30,8 +30,7 @@ spec:
     spec:
       initContainers:
       {{ include "charts.init.shoreline" .}}
-{{ if .Values.serviceAccount.create }}
-      serviceAccount: blob
+{{ if .Values.serviceAccount.name }}
       serviceAccountName: blob
 {{- end }}
       securityContext:

--- a/charts/tidepool/0.1.7/charts/blob/templates/blob-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/blob/templates/blob-deployment.yaml
@@ -34,6 +34,8 @@ spec:
       serviceAccount: blob
       serviceAccountName: blob
 {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
       - env:
         {{ include "charts.platform.env.mongo" .}}
@@ -61,6 +63,4 @@ spec:
         - containerPort: {{.Values.global.ports.blob}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/blob/templates/blob-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/blob/templates/blob-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       initContainers:
       {{ include "charts.init.shoreline" .}}
 {{ if .Values.serviceAccount.name }}
-      serviceAccountName: blob
+      serviceAccountName: {{ .Values.serviceAccount.name }}
 {{- end }}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}

--- a/charts/tidepool/0.1.7/charts/data/templates/data-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/data/templates/data-deployment.yaml
@@ -55,6 +55,6 @@ spec:
         - containerPort: {{.Values.global.ports.data}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/export/templates/export-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/export/templates/export-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - containerPort: {{.Values.global.ports.export}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always
 {{- end }}

--- a/charts/tidepool/0.1.7/charts/gatekeeper/templates/gatekeeper-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/gatekeeper/templates/gatekeeper-deployment.yaml
@@ -69,6 +69,6 @@ spec:
         - containerPort: {{.Values.global.ports.gatekeeper}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/highwater/templates/highwater-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/highwater/templates/highwater-deployment.yaml
@@ -89,6 +89,6 @@ spec:
         - containerPort: {{.Values.global.ports.highwater}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/hydrophone/templates/hydrophone-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/hydrophone/templates/hydrophone-deployment.yaml
@@ -30,9 +30,8 @@ spec:
     spec:
       initContainers:
       {{ include "charts.init.shoreline" .}}
-{{ if .Values.serviceAccount.create }}
-      serviceAccount: hydrophone
-      serviceAccountName: hydrophone
+{{ if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
 {{- end }}
       containers:
       - env:

--- a/charts/tidepool/0.1.7/charts/hydrophone/templates/hydrophone-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/hydrophone/templates/hydrophone-deployment.yaml
@@ -100,6 +100,6 @@ spec:
         - containerPort: {{.Values.global.ports.hydrophone}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/image/templates/image-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/image/templates/image-deployment.yaml
@@ -29,9 +29,8 @@ spec:
     spec:
       initContainers:
       {{ include "charts.init.shoreline" .}}
-{{ if .Values.serviceAccount.create }}
-      serviceAccount: image
-      serviceAccountName: image
+{{ if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
 {{- end }}
       containers:
       - env:

--- a/charts/tidepool/0.1.7/charts/image/templates/image-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/image/templates/image-deployment.yaml
@@ -60,6 +60,6 @@ spec:
         - containerPort: {{.Values.global.ports.image}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/jellyfish/templates/jellyfish-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/jellyfish/templates/jellyfish-deployment.yaml
@@ -87,6 +87,6 @@ spec:
         - containerPort: {{ .Values.global.ports.jellyfish }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/jellyfish/templates/jellyfish-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/jellyfish/templates/jellyfish-deployment.yaml
@@ -28,9 +28,8 @@ spec:
         app.kubernetes.io/name: {{ include "charts.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-{{ if .Values.serviceAccount.create }}
-      serviceAccount: jellyfish
-      serviceAccountName: jellyfish
+{{ if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
 {{- end }}
       containers:
       - env:

--- a/charts/tidepool/0.1.7/charts/messageapi/templates/message-api-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/messageapi/templates/message-api-deployment.yaml
@@ -74,6 +74,6 @@ spec:
         - containerPort: {{.Values.global.ports.messageapi}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/migrations/templates/migrations-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/migrations/templates/migrations-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         name: migrations
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always
 {{- end }}

--- a/charts/tidepool/0.1.7/charts/notification/templates/notification-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/notification/templates/notification-deployment.yaml
@@ -49,6 +49,6 @@ spec:
         - containerPort: {{.Values.global.ports.notification}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/seagull/templates/seagull-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/seagull/templates/seagull-deployment.yaml
@@ -68,6 +68,6 @@ spec:
         - containerPort: {{.Values.global.ports.seagull}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/shoreline/templates/shoreline-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/shoreline/templates/shoreline-deployment.yaml
@@ -148,6 +148,6 @@ spec:
         - containerPort: {{ .Values.global.ports.shoreline }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/task/templates/task-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/task/templates/task-deployment.yaml
@@ -53,6 +53,6 @@ spec:
         - containerPort: {{.Values.global.ports.task}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+          {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/tidewhisperer/templates/tide-whisperer-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/tidewhisperer/templates/tide-whisperer-deployment.yaml
@@ -92,6 +92,6 @@ spec:
         - containerPort: {{.Values.global.ports.tidewhisperer}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+          {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always

--- a/charts/tidepool/0.1.7/charts/tools/templates/tools-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/tools/templates/tools-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         name: tools
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always
 {{- end }}

--- a/charts/tidepool/0.1.7/charts/user/templates/user-deployment.yaml
+++ b/charts/tidepool/0.1.7/charts/user/templates/user-deployment.yaml
@@ -71,6 +71,6 @@ spec:
         - containerPort: {{.Values.global.ports.user}}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       restartPolicy: Always


### PR DESCRIPTION
See https://github.com/kubernetes-incubator/external-dns/pull/1185#issuecomment-530439786

Also, split arguments to script to get secrets from AWS Secrets Manager.

The movement of the SecurityContext is because there are *2* different Security Context objects.  We need access to the outer one to workaround the bug.