### PR TITLE
Add ability to select which gloo custom resources to generate

### DIFF
--- a/charts/tidepool/0.1.7/README.md
+++ b/charts/tidepool/0.1.7/README.md
@@ -108,6 +108,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `global.fullnameOverride`                                |                                                                                              | ``                                                    |
 | `global.gateway.default.host`                          | Host to use for email verification                                                      | `localhost`   |
 | `global.gateway.default.protocol`                          | Protocol to use for email verification.                                                      | `http`                                                    |
+| `global.gateway.default.domain`                          | Domain to use for cookies
 | `global.logLevel`                              | Default log level | `info`                                        |
 | `global.nameOverride`                                    | If non-empty, Helm chart name to use                                                         | ``                                                    |
 | `global.ports.auth`                                      | Auth service container port                                                                  | `9222`                                                |
@@ -129,10 +130,13 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `global.ports.user`                                      | User service container port                                                                  | `9221`
 | `global.region`                                  | AWS region to deploy in                                                                      | `us-west-2`                                           |
 | `global.secret.enabled`                                  | whether to generate all secret files | `false`                                           |
-| `gloo.enabled`                                           | Whether to include an API Gateway with this installation                                     | `true`                                                |
-| `gloo.gatewayProxies.gatewayProxyV2.service.httpPort`  | HTTP port to listen to | `8080`                                                  |
-| `gloo.gatewayProxies.gatewayProxyV2.service.httpsPort`  | HTTPS port to listen to | `8433`                                                  |
-| `gloo.gatewayProxies.gatewayProxyV2.service.type`  | Type on service | `ClusterIP`                                                  |
+| `gloo.enabled`                                           | Whether to launch Gloo control and plane
+| `gloo.generate.virtualServices`                          | Whether to include an Gloo virtual services resources in installation
+| `gloo.generate.gateways`                          | Whether to include a Gloo vGateway resources
+| `gloo.generate.loadBalancer`                          | Whether to include a load balancer
+| `gloo.gatewayProxies.gatewayProxy.service.httpPort`  | HTTP port to listen to | `8080`                                                  |
+| `gloo.gatewayProxies.gatewayProxy.service.httpsPort`  | HTTPS port to listen to | `8433`                                                  |
+| `gloo.gatewayProxies.gatewayProxy.service.type`  | Type on service | `ClusterIP`                                                  |
 | `highwater.deployment.image` | highwater Docker image | `` |
 | `highwater.nodeEnvironment`                     | Node environment (passed as NODE_ENV)                                                        | `production`                                          |
 | `hydrophone.deployment.env.fromAddress`                                 | Email address to use for replies to sigups                                                   | `Tidepool <noreply@tidepool.org>`                     |

--- a/charts/tidepool/0.1.7/README.md
+++ b/charts/tidepool/0.1.7/README.md
@@ -166,6 +166,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `kissmetrics.secret.data_.Token` | plaintext Kissmetrics Token | `` |
 | `kissmetrics.secret.data_.UCSFAPIKey` | plaintext UCSF Kissmetrics Token | `` |
 | `kissmetrics.secret.data_.UCSFWhitelist` | plaintext UCSF metrics whitelist | `` |
+| `linkerd.generate.serviceProfiles` | whether to generate Linkerd ServiceProfiles | `false` |
 | `mailchimp.secret.enabled` | whether to create Mailchimp secret | `false` |
 | `mailchimp.secret.data_.ApiKey` | plaintext Mailchimp API key | `` |
 | `mailchimp.secret.data_.ClinicLists` | plaintext clinic mailing lists| `` |

--- a/charts/tidepool/0.1.7/templates/external-service.yaml
+++ b/charts/tidepool/0.1.7/templates/external-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.gloo.enabled }}
+{{ if .Values.gloo.generate.loadBalancer }}
 {{ if or .Values.ingress.service.http.enabled .Values.ingress.service.https.enabled -}}
 ---
 apiVersion: v1

--- a/charts/tidepool/0.1.7/templates/gateway-ssl.yaml
+++ b/charts/tidepool/0.1.7/templates/gateway-ssl.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.gloo.enabled }}
+{{ if .Values.gloo.generate.gateways }}
 apiVersion: gateway.solo.io/v1
 kind: Gateway
 metadata:

--- a/charts/tidepool/0.1.7/templates/gateway.yaml
+++ b/charts/tidepool/0.1.7/templates/gateway.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.gloo.enabled }}
+{{ if .Values.gloo.generate.gateways }}
 apiVersion: gateway.solo.io/v1
 kind: Gateway
 metadata:

--- a/charts/tidepool/0.1.7/templates/gloo-http-internal-virtual-service.yaml
+++ b/charts/tidepool/0.1.7/templates/gloo-http-internal-virtual-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.gloo.generate.virtualServices }}
 ---
 # file: gloo-internal-virtualservice.yaml
 apiVersion: gateway.solo.io/v1
@@ -16,3 +17,4 @@ spec:
       delegateAction:
         name: 'tidepool-routes'
         namespace: {{ $.Release.Namespace }}
+{{ end }}

--- a/charts/tidepool/0.1.7/templates/gloo-http-virtual-service.yaml
+++ b/charts/tidepool/0.1.7/templates/gloo-http-virtual-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.gloo.generate.virtualServices }}
 {{- if .Values.ingress.service.http.enabled -}}
 {{- $spec := .Values.ingress.gateway.http -}}
 {{- $port := $spec.port | default "80" -}}
@@ -29,4 +30,5 @@ spec:
         name: 'tidepool-routes'
         namespace: {{ $.Release.Namespace }}
 {{ end }}
+{{- end -}}
 {{- end -}}

--- a/charts/tidepool/0.1.7/templates/gloo-https-virtual-service.yaml
+++ b/charts/tidepool/0.1.7/templates/gloo-https-virtual-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.gloo.generate.virtualServices }}
 {{- if .Values.ingress.service.https.enabled -}}
 {{- $spec := .Values.ingress.gateway.https -}}
 {{- $port := $spec.port | default "443" -}}
@@ -58,4 +59,5 @@ spec:
       delegateAction:
         name: 'tidepool-routes'
         namespace: {{ .Release.Namespace }}
+{{ end -}}
 {{ end -}}

--- a/charts/tidepool/0.1.7/templates/serviceprofiles.yaml
+++ b/charts/tidepool/0.1.7/templates/serviceprofiles.yaml
@@ -1,0 +1,1237 @@
+{{ if .Values.linkerd.generate.serviceProfiles }}
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: auth.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/restricted_tokens
+    name: /v1/users/{id}/restricted_tokens_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/restricted_tokens
+    name: /v1/users/{id}/restricted_tokens_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/restricted_tokens
+    name: /v1/users/{id}/restricted_tokens_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/provider_sessions
+    name: /v1/users/{id}/provider_sessions_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/provider_sessions
+    name: /v1/users/{id}/provider_sessions_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/provider_sessions
+    name: /v1/users/{id}/provider_sessions_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/provider_sessions/[^/]+
+    name: /v1/provider_sessions/{id}_get
+  - condition:
+      method: PUT
+      pathRegex: /v1/provider_sessions/[^/]+
+    name: /v1/provider_sessions/{id}_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/provider_sessions/[^/]+
+    name: /v1/provider_sessions/{id}_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/oauth/[^/]+/authorize
+    name: /v1/oauth/{id}/authorize_get
+  - condition:
+      method: DELETE
+      pathRegex: /v1/oauth/[^/]+/authorize
+    name: /v1/oauth/{id}/authorize_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/oauth/[^/]+/redirect
+    name: /v1/oauth/{id}/redirect_get
+  - condition:
+      method: GET
+      pathRegex: /v1/restricted_tokens.*
+    name: /v1/restricted_tokens_get
+  - condition:
+      method: PUT
+      pathRegex: /v1/restricted_tokens.*
+    name: /v1/restricted_tokens_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/restricted_tokens.*
+    name: /v1/restricted_tokens_delete
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: blip.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /request-password-from-uploader.*
+    name: /request-password-from-uploader_get
+  - condition:
+      method: GET
+      pathRegex: /verification-with-password.*
+    name: /verification-with-password_get
+  - condition:
+      method: POST
+      pathRegex: /event/csp-report/violation.*
+    name: /event/csp-report/violation_post
+  - condition:
+      method: GET
+      pathRegex: /request-password-reset.*
+    name: /request-password-reset_get
+  - condition:
+      method: GET
+      pathRegex: /confirm-password-reset.*
+    name: /confirm-password-reset_get
+  - condition:
+      method: GET
+      pathRegex: /email-verification.*
+    name: /email-verification_get
+  - condition:
+      method: GET
+      pathRegex: /clinician-details.*
+    name: /clinician-details_get
+  - condition:
+      method: GET
+      pathRegex: /browser-warning.*
+    name: /browser-warning_get
+  - condition:
+      method: GET
+      pathRegex: /patients.*
+    name: /patients_get
+  - condition:
+      method: GET
+      pathRegex: /profile.*
+    name: /profile_get
+  - condition:
+      method: GET
+      pathRegex: /signup.*
+    name: /signup_get
+  - condition:
+      method: GET
+      pathRegex: /terms.*
+    name: /terms_get
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: /_get
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: blob.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /v1/blobs/[^/]+/content
+    name: /v1/blobs/{id}/content_get
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/blobs
+    name: /v1/users/{id}/blobs_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/blobs
+    name: /v1/users/{id}/blobs_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/blobs
+    name: /v1/users/{id}/blobs_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/blobs/[^/]+
+    name: /v1/blobs/{id}_get
+  - condition:
+      method: DELETE
+      pathRegex: /v1/blobs/[^/]+
+    name: /v1/blobs/{id}_delete
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: data.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/data_sources
+    name: /v1/users/{id}/data_sources_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/data_sources
+    name: /v1/users/{id}/data_sources_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/data_sources
+    name: /v1/users/{id}/data_sources_delete
+  - condition:
+      method: OPTIONS
+      pathRegex: /v1/users/[^/]+/data_sources
+    name: /v1/users/{id}/data_sources_options
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/data_sets
+    name: /v1/users/{id}/data_sets_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/data_sets
+    name: /v1/users/{id}/data_sets_post
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/datasets
+    name: /v1/users/{id}/datasets_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/datasets
+    name: /v1/users/{id}/datasets_post
+  - condition:
+      method: GET
+      pathRegex: /v1/data_sources/[^/]+
+    name: /v1/data_sources/{id}_get
+  - condition:
+      method: PUT
+      pathRegex: /v1/data_sources/[^/]+
+    name: /v1/data_sources/{id}_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/data_sources/[^/]+
+    name: /v1/data_sources/{id}_delete
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/data
+    name: /v1/users/{id}/data_delete
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: /dataservices/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /.*
+    name: /dataservices/_options
+  - condition:
+      method: POST
+      pathRegex: /.*
+    name: /dataservices/_post
+  - condition:
+      method: PUT
+      pathRegex: /.*
+    name: /dataservices/_put
+  - condition:
+      method: PATCH
+      pathRegex: /.*
+    name: /dataservices/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /.*
+    name: /dataservices/_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/data_sets.*
+    name: /v1/data_sets_get
+  - condition:
+      method: POST
+      pathRegex: /v1/data_sets.*
+    name: /v1/data_sets_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/data_sets.*
+    name: /v1/data_sets_delete
+  - condition:
+      method: PUT
+      pathRegex: /v1/data_sets.*
+    name: /v1/data_sets_put
+  - condition:
+      method: POST
+      pathRegex: /v1/datasets.*
+    name: /v1/datasets_post
+  - condition:
+      method: PUT
+      pathRegex: /v1/datasets.*
+    name: /v1/datasets_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/datasets.*
+    name: /v1/datasets_delete
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: /v1/data/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /.*
+    name: /v1/data/_options
+  - condition:
+      method: POST
+      pathRegex: /.*
+    name: /v1/data/_post
+  - condition:
+      method: PUT
+      pathRegex: /.*
+    name: /v1/data/_put
+  - condition:
+      method: PATCH
+      pathRegex: /.*
+    name: /v1/data/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /.*
+    name: /v1/data/_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/time.*
+    name: /v1/time_get
+  ---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: export.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /export/.*
+    name: /export/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /export/.*
+    name: /export/_options
+  - condition:
+      method: POST
+      pathRegex: /export/.*
+    name: /export/_post
+  - condition:
+      method: PUT
+      pathRegex: /export/.*
+    name: /export/_put
+  - condition:
+      method: PATCH
+      pathRegex: /export/.*
+    name: /export/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /export/.*
+    name: /export/_delete
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: gatekeeper.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /access/.*
+    name: /access/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /access/.*
+    name: /access/_options
+  - condition:
+      method: POST
+      pathRegex: /access/.*
+    name: /access/_post
+  - condition:
+      method: PUT
+      pathRegex: /access/.*
+    name: /access/_put
+  - condition:
+      method: PATCH
+      pathRegex: /access/.*
+    name: /access/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /access/.*
+    name: /access/_delete
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: highwater.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: /metrics/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /.*
+    name: /metrics/_options
+  - condition:
+      method: POST
+      pathRegex: /.*
+    name: /metrics/_post
+  - condition:
+      method: PUT
+      pathRegex: /.*
+    name: /metrics/_put
+  - condition:
+      method: PATCH
+      pathRegex: /.*
+    name: /metrics/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /.*
+    name: /metrics/_delete
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: hydrophone.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: /confirm/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /.*
+    name: /confirm/_options
+  - condition:
+      method: POST
+      pathRegex: /.*
+    name: /confirm/_post
+  - condition:
+      method: PUT
+      pathRegex: /.*
+    name: /confirm/_put
+  - condition:
+      method: PATCH
+      pathRegex: /.*
+    name: /confirm/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /.*
+    name: /confirm/_delete
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: image.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/images/.+
+    name: /v1/users/{id}/images/.+_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/images/.+
+    name: /v1/users/{id}/images/.+_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/images/.+
+    name: /v1/users/{id}/images/.+_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/images
+    name: /v1/users/{id}/images_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/images
+    name: /v1/users/{id}/images_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/images
+    name: /v1/users/{id}/images_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/images.*
+    name: /v1/images_get
+  - condition:
+      method: PUT
+      pathRegex: /v1/images.*
+    name: /v1/images_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/images.*
+    name: /v1/images_delete
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: internal.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /
+    name: /v1/users/{id}/restricted_tokens_get
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/restricted_tokens
+    name: /v1/users/{id}/restricted_tokens_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/restricted_tokens
+    name: /v1/users/{id}/restricted_tokens_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/restricted_tokens
+    name: /v1/users/{id}/restricted_tokens_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/provider_sessions
+    name: /v1/users/{id}/provider_sessions_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/provider_sessions
+    name: /v1/users/{id}/provider_sessions_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/provider_sessions
+    name: /v1/users/{id}/provider_sessions_delete
+  - condition:
+      method: GET
+      pathRegex: /request-password-from-uploader
+    name: /request-password-from-uploader_get
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/data_sources
+    name: /v1/users/{id}/data_sources_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/data_sources
+    name: /v1/users/{id}/data_sources_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/data_sources
+    name: /v1/users/{id}/data_sources_delete
+  - condition:
+      method: OPTIONS
+      pathRegex: /v1/users/[^/]+/data_sources
+    name: /v1/users/{id}/data_sources_options
+  - condition:
+      method: GET
+      pathRegex: /v1/provider_sessions/[^/]+
+    name: /v1/provider_sessions/{id}_get
+  - condition:
+      method: PUT
+      pathRegex: /v1/provider_sessions/[^/]+
+    name: /v1/provider_sessions/{id}_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/provider_sessions/[^/]+
+    name: /v1/provider_sessions/{id}_delete
+  - condition:
+      method: GET
+      pathRegex: /verification-with-password
+    name: /verification-with-password_get
+  - condition:
+      method: POST
+      pathRegex: /event/csp-report/violation
+    name: /event/csp-report/violation_post
+  - condition:
+      method: GET
+      pathRegex: /v1/oauth/[^/]+/authorize
+    name: /v1/oauth/{id}/authorize_get
+  - condition:
+      method: DELETE
+      pathRegex: /v1/oauth/[^/]+/authorize
+    name: /v1/oauth/{id}/authorize_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/data_sets
+    name: /v1/users/{id}/data_sets_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/data_sets
+    name: /v1/users/{id}/data_sets_post
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/images/.+
+    name: /v1/users/{id}/images/.+_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/images/.+
+    name: /v1/users/{id}/images/.+_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/images/.+
+    name: /v1/users/{id}/images/.+_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/oauth/[^/]+/redirect
+    name: /v1/oauth/{id}/redirect_get
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/datasets
+    name: /v1/users/{id}/datasets_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/datasets
+    name: /v1/users/{id}/datasets_post
+  - condition:
+      method: GET
+      pathRegex: /request-password-reset
+    name: /request-password-reset_get
+  - condition:
+      method: GET
+      pathRegex: /confirm-password-reset
+    name: /confirm-password-reset_get
+  - condition:
+      method: GET
+      pathRegex: /v1/blobs/[^/]+/content
+    name: /v1/blobs/{id}/content_get
+  - condition:
+      method: GET
+      pathRegex: /v1/data_sources/[^/]+
+    name: /v1/data_sources/{id}_get
+  - condition:
+      method: PUT
+      pathRegex: /v1/data_sources/[^/]+
+    name: /v1/data_sources/{id}_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/data_sources/[^/]+
+    name: /v1/data_sources/{id}_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/images
+    name: /v1/users/{id}/images_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/images
+    name: /v1/users/{id}/images_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/images
+    name: /v1/users/{id}/images_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/restricted_tokens
+    name: /v1/restricted_tokens_get
+  - condition:
+      method: PUT
+      pathRegex: /v1/restricted_tokens
+    name: /v1/restricted_tokens_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/restricted_tokens
+    name: /v1/restricted_tokens_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/]+/blobs
+    name: /v1/users/{id}/blobs_get
+  - condition:
+      method: POST
+      pathRegex: /v1/users/[^/]+/blobs
+    name: /v1/users/{id}/blobs_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/blobs
+    name: /v1/users/{id}/blobs_delete
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/]+/data
+    name: /v1/users/{id}/data_delete
+  - condition:
+      method: POST
+      pathRegex: /v1/device/upload/cl
+    name: /v1/device/upload/cl_post
+  - condition:
+      method: GET
+      pathRegex: /email-verification
+    name: /email-verification_get
+  - condition:
+      method: GET
+      pathRegex: /clinician-details
+    name: /clinician-details_get
+  - condition:
+      method: GET
+      pathRegex: /v1/device/data/
+    name: /v1/device/data/_get
+  - condition:
+      method: GET
+      pathRegex: /browser-warning
+    name: /browser-warning_get
+  - condition:
+      method: GET
+      pathRegex: /v1/blobs/[^/]+
+    name: /v1/blobs/{id}_get
+  - condition:
+      method: DELETE
+      pathRegex: /v1/blobs/[^/]+
+    name: /v1/blobs/{id}_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/tasks/[^/*]
+    name: /v1/tasks/{id2}_get
+  - condition:
+      method: PUT
+      pathRegex: /v1/tasks/[^/*]
+    name: /v1/tasks/{id2}_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/tasks/[^/*]
+    name: /v1/tasks/{id2}_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/*]
+    name: /v1/users/{id2}_get
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/*]
+    name: /v1/users/{id2}_delete
+  - condition:
+      method: GET
+      pathRegex: /dataservices/
+    name: /dataservices/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /dataservices/
+    name: /dataservices/_options
+  - condition:
+      method: POST
+      pathRegex: /dataservices/
+    name: /dataservices/_post
+  - condition:
+      method: PUT
+      pathRegex: /dataservices/
+    name: /dataservices/_put
+  - condition:
+      method: PATCH
+      pathRegex: /dataservices/
+    name: /dataservices/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /dataservices/
+    name: /dataservices/_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/synctasks/
+    name: /v1/synctasks/_get
+  - condition:
+      method: GET
+      pathRegex: /userservices/
+    name: /userservices/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /userservices/
+    name: /userservices/_options
+  - condition:
+      method: POST
+      pathRegex: /userservices/
+    name: /userservices/_post
+  - condition:
+      method: PUT
+      pathRegex: /userservices/
+    name: /userservices/_put
+  - condition:
+      method: PATCH
+      pathRegex: /userservices/
+    name: /userservices/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /userservices/
+    name: /userservices/_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/data_sets
+    name: /v1/data_sets_get
+  - condition:
+      method: POST
+      pathRegex: /v1/data_sets
+    name: /v1/data_sets_post
+  - condition:
+      method: DELETE
+      pathRegex: /v1/data_sets
+    name: /v1/data_sets_delete
+  - condition:
+      method: PUT
+      pathRegex: /v1/data_sets
+    name: /v1/data_sets_put
+  - condition:
+      method: POST
+      pathRegex: /v1/datasets
+    name: /v1/datasets_post
+  - condition:
+      method: PUT
+      pathRegex: /v1/datasets
+    name: /v1/datasets_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/datasets
+    name: /v1/datasets_delete
+  - condition:
+      method: POST
+      pathRegex: /serverlogin
+    name: /serverlogin_post
+  - condition:
+      method: GET
+      pathRegex: /v1/images
+    name: /v1/images_get
+  - condition:
+      method: PUT
+      pathRegex: /v1/images
+    name: /v1/images_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/images
+    name: /v1/images_delete
+  - condition:
+      method: GET
+      pathRegex: /metadata/
+    name: /metadata/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /metadata/
+    name: /metadata/_options
+  - condition:
+      method: POST
+      pathRegex: /metadata/
+    name: /metadata/_post
+  - condition:
+      method: PUT
+      pathRegex: /metadata/
+    name: /metadata/_put
+  - condition:
+      method: PATCH
+      pathRegex: /metadata/
+    name: /metadata/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /metadata/
+    name: /metadata/_delete
+  - condition:
+      method: GET
+      pathRegex: /patients
+    name: /patients_get
+  - condition:
+      method: GET
+      pathRegex: /v1/data/
+    name: /v1/data/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /v1/data/
+    name: /v1/data/_options
+  - condition:
+      method: POST
+      pathRegex: /v1/data/
+    name: /v1/data/_post
+  - condition:
+      method: PUT
+      pathRegex: /v1/data/
+    name: /v1/data/_put
+  - condition:
+      method: PATCH
+      pathRegex: /v1/data/
+    name: /v1/data/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /v1/data/
+    name: /v1/data/_delete
+  - condition:
+      method: GET
+      pathRegex: /metrics/
+    name: /metrics/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /metrics/
+    name: /metrics/_options
+  - condition:
+      method: POST
+      pathRegex: /metrics/
+    name: /metrics/_post
+  - condition:
+      method: PUT
+      pathRegex: /metrics/
+    name: /metrics/_put
+  - condition:
+      method: PATCH
+      pathRegex: /metrics/
+    name: /metrics/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /metrics/
+    name: /metrics/_delete
+  - condition:
+      method: GET
+      pathRegex: /confirm/
+    name: /confirm/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /confirm/
+    name: /confirm/_options
+  - condition:
+      method: POST
+      pathRegex: /confirm/
+    name: /confirm/_post
+  - condition:
+      method: PUT
+      pathRegex: /confirm/
+    name: /confirm/_put
+  - condition:
+      method: PATCH
+      pathRegex: /confirm/
+    name: /confirm/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /confirm/
+    name: /confirm/_delete
+  - condition:
+      method: GET
+      pathRegex: /message/
+    name: /message/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /message/
+    name: /message/_options
+  - condition:
+      method: POST
+      pathRegex: /message/
+    name: /message/_post
+  - condition:
+      method: PUT
+      pathRegex: /message/
+    name: /message/_put
+  - condition:
+      method: PATCH
+      pathRegex: /message/
+    name: /message/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /message/
+    name: /message/_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/tasks
+    name: /v1/tasks_get
+  - condition:
+      method: POST
+      pathRegex: /v1/tasks
+    name: /v1/tasks_post
+  - condition:
+      method: GET
+      pathRegex: /profile
+    name: /profile_get
+  - condition:
+      method: GET
+      pathRegex: /v1/time
+    name: /v1/time_get
+  - condition:
+      method: GET
+      pathRegex: /export/
+    name: /export/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /export/
+    name: /export/_options
+  - condition:
+      method: POST
+      pathRegex: /export/
+    name: /export/_post
+  - condition:
+      method: PUT
+      pathRegex: /export/
+    name: /export/_put
+  - condition:
+      method: PATCH
+      pathRegex: /export/
+    name: /export/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /export/
+    name: /export/_delete
+  - condition:
+      method: GET
+      pathRegex: /access/
+    name: /access/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /access/
+    name: /access/_options
+  - condition:
+      method: POST
+      pathRegex: /access/
+    name: /access/_post
+  - condition:
+      method: PUT
+      pathRegex: /access/
+    name: /access/_put
+  - condition:
+      method: PATCH
+      pathRegex: /access/
+    name: /access/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /access/
+    name: /access/_delete
+  - condition:
+      method: GET
+      pathRegex: /signup
+    name: /signup_get
+  - condition:
+      method: GET
+      pathRegex: /terms
+    name: /terms_get
+  - condition:
+      method: POST
+      pathRegex: /data/
+    name: /data/_post
+  - condition:
+      method: GET
+      pathRegex: /auth/
+    name: /auth/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /auth/
+    name: /auth/_options
+  - condition:
+      method: POST
+      pathRegex: /auth/
+    name: /auth/_post
+  - condition:
+      method: PUT
+      pathRegex: /auth/
+    name: /auth/_put
+  - condition:
+      method: PATCH
+      pathRegex: /auth/
+    name: /auth/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /auth/
+    name: /auth/_delete
+  - condition:
+      method: GET
+      pathRegex: /data/.*
+    name: /data/_get
+  - condition:
+      method: GET
+      pathRegex: /info
+    name: /info_get
+  - condition:
+      method: GET
+      pathRegex: /
+    name: /_get
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: jellyfish.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: POST
+      pathRegex: /v1/device/upload/cl.*
+    name: /v1/device/upload/cl_post
+  - condition:
+      method: GET
+      pathRegex: /v1/device/data/.*
+    name: /v1/device/data/_get
+  - condition:
+      method: GET
+      pathRegex: /v1/synctasks/.*
+    name: /v1/synctasks/_get
+  - condition:
+      method: POST
+      pathRegex: /data/.*
+    name: /data/_post
+  - condition:
+      method: GET
+      pathRegex: /info.*
+    name: /info_get
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: message-api.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: /message/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /.*
+    name: /message/_options
+  - condition:
+      method: POST
+      pathRegex: /.*
+    name: /message/_post
+  - condition:
+      method: PUT
+      pathRegex: /.*
+    name: /message/_put
+  - condition:
+      method: PATCH
+      pathRegex: /.*
+    name: /message/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /.*
+    name: /message/_delete
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: seagull.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: /metadata/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /.*
+    name: /metadata/_options
+  - condition:
+      method: POST
+      pathRegex: /.*
+    name: /metadata/_post
+  - condition:
+      method: PUT
+      pathRegex: /.*
+    name: /metadata/_put
+  - condition:
+      method: PATCH
+      pathRegex: /.*
+    name: /metadata/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /.*
+    name: /metadata/_delete
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: shoreline.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: POST
+      pathRegex: /serverlogin.*
+    name: /serverlogin_post
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: /auth/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /.*
+    name: /auth/_options
+  - condition:
+      method: POST
+      pathRegex: /.*
+    name: /auth/_post
+  - condition:
+      method: PUT
+      pathRegex: /.*
+    name: /auth/_put
+  - condition:
+      method: PATCH
+      pathRegex: /.*
+    name: /auth/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /.*
+    name: /auth/_delete
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: task.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /v1/tasks/[^/*]
+    name: /v1/tasks/{id2}_get
+  - condition:
+      method: PUT
+      pathRegex: /v1/tasks/[^/*]
+    name: /v1/tasks/{id2}_put
+  - condition:
+      method: DELETE
+      pathRegex: /v1/tasks/[^/*]
+    name: /v1/tasks/{id2}_delete
+  - condition:
+      method: GET
+      pathRegex: /v1/tasks.*
+    name: /v1/tasks_get
+  - condition:
+      method: POST
+      pathRegex: /v1/tasks.*
+    name: /v1/tasks_post
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: tide-whisperer.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: /data/_get
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: user.{{ .Release.Namespace }}.svc.cluster.local
+  namespace: {{ .Release.Namespace }}
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /v1/users/[^/*]
+    name: /v1/users/{id2}_get
+  - condition:
+      method: DELETE
+      pathRegex: /v1/users/[^/*]
+    name: /v1/users/{id2}_delete
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: /userservices/_get
+  - condition:
+      method: OPTIONS
+      pathRegex: /.*
+    name: /userservices/_options
+  - condition:
+      method: POST
+      pathRegex: /.*
+    name: /userservices/_post
+  - condition:
+      method: PUT
+      pathRegex: /.*
+    name: /userservices/_put
+  - condition:
+      method: PATCH
+      pathRegex: /.*
+    name: /userservices/_patch
+  - condition:
+      method: DELETE
+      pathRegex: /.*
+    name: /userservices/_delete
+{{ end }}

--- a/charts/tidepool/0.1.7/values.yaml
+++ b/charts/tidepool/0.1.7/values.yaml
@@ -36,6 +36,10 @@ tidepool:
     create: true
     annotations: {}                             # namespace annotations
 
+linkerd:
+  generate:
+    serviceProfiles: false
+
 ingress:
   service:
     http:

--- a/charts/tidepool/0.1.7/values.yaml
+++ b/charts/tidepool/0.1.7/values.yaml
@@ -54,6 +54,10 @@ ingress:
       dnsNames: []                              # list of DNS names
 gloo:
   enabled: true
+  generate:
+   virtualServices: true
+   gateways: true
+   loadBalancer: true
   settings:
     create: true
   crds:


### PR DESCRIPTION
Add ability to select which Gloo custom resources to generate.
Update docs to reflect changes in naming from shift to Gloo 1.0 (gatewayProxyV2-> gatewayProxy)
Add documentation of `global.gateway.default.domain`

These changes are intended to be backward compatible