### PR TITLE
Work around envoy issue

### DIFF
--- a/charts/tidepool/0.1.7/templates/gloo-routetable.yaml
+++ b/charts/tidepool/0.1.7/templates/gloo-routetable.yaml
@@ -474,41 +474,8 @@ spec:
   - matchers:
     - methods:
       - GET
-      prefix: /access/status
-    routeAction:
-      single:
-        kube:
-          ref:
-            name: gatekeeper
-            namespace: '{{ .Release.Namespace }}'
-          port: {{ .Values.global.ports.gatekeeper }}
-  - matchers:
-    - methods:
-      - GET
-      prefix: /access/groups/
-    routeAction:
-      single:
-        kube:
-          ref:
-            name: gatekeeper
-            namespace: '{{ .Release.Namespace }}'
-          port: {{ .Values.global.ports.gatekeeper }}
-  - matchers:
-    - methods:
-      - GET
       - POST
-      prefix: /access/[^/]+/[^/]+
-    routeAction:
-      single:
-        kube:
-          ref:
-            name: gatekeeper
-            namespace: '{{ .Release.Namespace }}'
-          port: {{ .Values.global.ports.gatekeeper }}
-  - matchers:
-    - methods:
-      - GET
-      prefix: /access/[^/]+
+      prefix: /access/
     routeAction:
       single:
         kube:


### PR DESCRIPTION
For some reason, splitting out the `/access/` paths causes a pattern matching issue for envoy. 