### PR TITLE
Fix prefix (WEB-711)

### DIFF
--- a/charts/tidepool/0.1.7/templates/gloo-routetable.yaml
+++ b/charts/tidepool/0.1.7/templates/gloo-routetable.yaml
@@ -497,7 +497,7 @@ spec:
     - methods:
       - GET
       - POST
-      prefix: /access/[^/]+/[^/]+
+      regex: /access/[^/]+/[^/]+
     routeAction:
       single:
         kube:
@@ -508,7 +508,7 @@ spec:
   - matchers:
     - methods:
       - GET
-      prefix: /access/[^/]+
+      regex: /access/[^/]+
     routeAction:
       single:
         kube:


### PR DESCRIPTION
The key name of the prefix is incorrect in two cases.  It should be "regex" since the pattern is a regex.