### PR TITLE
Add metrics-server to local cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ docker-compose.override.yml
 *.swp
 local/*
 !local/README.md
+!local/metrics-server.yml

--- a/README.md
+++ b/README.md
@@ -331,7 +331,9 @@ This can be done with the `tidepool` helper script:
 tidepool server-init-metrics
 ```
 
-NOTE: This only needs to be run once. After the running the command, and each time the server starts up, it will take a minute or two before the metrics start showing up.
+This only needs to be run once. After the running the command, and each time the server starts up, it will take a minute or two before the metrics start showing up.
+
+If you're running the K9s UI during the initial deployment, you'll need to restart it to see the metrics coming in.
 
 [[back to top]](#welcome)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Of course, if you haven't already done so, you should check out [Tidepool](https
   - [With The Tidepool Helper Script (recommended)](#with-the-tidepool-helper-script-recommended)
   - [Without The Tidepool Helper Script](#without-the-tidepool-helper-script)
   - [Monitor Kubernetes State With K9s (Optional)](#monitor-kubernetes-state-with-k9s-optional)
+  - [Add CPU/MEM Usage Metrics (Optional)](#add-cpumem-usage-metrics-optional)
 - [Using Tidepool](#using-tidepool)
   - [Creating An Account](#creating-an-account)
   - [Verifying An Account Email](#verifying-an-account-email)
@@ -319,6 +320,18 @@ After [Installing the k9s CLI](https://github.com/derailed/k9s#installation), yo
 ```bash
 k9s
 ```
+
+## Add CPU/MEM Usage Metrics (Optional)
+
+If you would like to see metrics for CPU and Memory usage in, for instance, the K9s UI, you'll need to install the kubernetes `metrics-server` service.
+
+This can be done with the `tidepool` helper script:
+
+```bash
+tidepool server-init-metrics
+```
+
+NOTE: This only needs to be run once. After the running the command, and each time the server starts up, it will take a minute or two before the metrics start showing up.
 
 [[back to top]](#welcome)
 

--- a/bin/tidepool
+++ b/bin/tidepool
@@ -110,10 +110,58 @@ destroy() {
   echo
   if [[ $REPLY =~ ^[Yy]$ ]]
   then
-    run_docker_compose rm -fsv
+    cd ${DIR} && run_docker_compose rm -fsv
     rm -r ${DIR}/local/charts
   else
     echo "Destroy command aborted"
+  fi
+}
+
+init-metrics-server() {
+  read -p "Continuing will require us to remove your ~/.helm directory if present. Do you want to continue? [N|y] " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]
+  then
+    # Add --authentication-token-webhook=true line to kubelet.sh in server container
+    cd ${DIR} && docker-compose -f 'docker-compose.k8s.yml' exec server sh -c "sed -i '/--authorization-mode=Webhook/a --authentication-token-webhook=true \\\' kubelet.sh"
+
+    # Restart the server and wait till ready
+    cd ${DIR} && run_docker_compose restart
+    set_kubeconfig
+
+    sleep 10
+
+    # Wait until kubectl ready
+    until kubectl api-resources; do
+      sleep 5;
+    done
+
+    # Remove tiller if present
+    helm reset || true
+    rm -rf ~/.helm
+    kubectl delete deployment tiller-deploy --namespace kube-system --ignore-not-found
+    kubectl delete serviceaccount --namespace kube-system tiller --ignore-not-found
+    kubectl delete clusterrolebinding tiller-cluster-rule --ignore-not-found
+
+    # Create necessary helm service account and clusterrolebinding for tiller
+    kubectl create serviceaccount --namespace kube-system tiller
+    kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+
+    # Install tiller
+    helm init --service-account tiller --upgrade
+
+    sleep 10
+
+    # Wait until tiller ready
+    until helm list; do
+      sleep 5;
+    done
+
+    # (Re)Install metrics server
+    helm delete --purge metrics-server || true
+    helm install stable/metrics-server -f ${DIR}/local/metrics-server.yml --name metrics-server
+  else
+    echo "Metrics server initialization aborted"
   fi
 }
 
@@ -135,5 +183,6 @@ case ${1-help} in
   port-forward) (cd ${DIR} && kubectl port-forward svc/${2} ${3});;
   verify-account-email) mongo_exec "mongo --eval 'db.users.update({username: \"${@:2}\"},{\$set:{\"authenticated\":true}});' user";;
   restart-proxy) restart gateway-proxy;;
+  init-metrics-server) init-metrics-server;;
   *) usage;;
 esac

--- a/bin/tidepool
+++ b/bin/tidepool
@@ -18,6 +18,9 @@ USAGE: tidepool command [service] [...additional args]
   server-set-config               Save Kubernetes server config to ~/.kube/config. Required only
                                   after the initial provisioning
 
+  server-init-metrics             Initializes a metrics-server deployment to allow viewing CPU and
+                                  MEM usage metrics for all cluster resources
+
   server-docker [...cmds]         Run docker commands within the context of the Kubernetes server
   server-exec [...cmds]           Run shell commands in the Kubernetes server container
 
@@ -117,7 +120,7 @@ destroy() {
   fi
 }
 
-init-metrics-server() {
+init_metrics_server() {
   read -p "Continuing will require us to remove your ~/.helm directory if present. Do you want to continue? [N|y] " -n 1 -r
   echo
   if [[ $REPLY =~ ^[Yy]$ ]]
@@ -170,6 +173,7 @@ case ${1-help} in
   server-stop) (cd ${DIR} && run_docker_compose stop ${2-});;
   server-logs) (cd ${DIR} && run_docker_compose logs --tail=100 -f server);;
   server-set-config) set_kubeconfig;;
+  server-init-metrics) init_metrics_server;;
   server-docker) run_docker "${@:2}";;
   server-exec) (cd ${DIR} && run_docker_compose exec server sh);;
   server-prune) (run_docker "system prune --volumes -af");;
@@ -183,6 +187,5 @@ case ${1-help} in
   port-forward) (cd ${DIR} && kubectl port-forward svc/${2} ${3});;
   verify-account-email) mongo_exec "mongo --eval 'db.users.update({username: \"${@:2}\"},{\$set:{\"authenticated\":true}});' user";;
   restart-proxy) restart gateway-proxy;;
-  init-metrics-server) init-metrics-server;;
   *) usage;;
 esac

--- a/local/metrics-server.yml
+++ b/local/metrics-server.yml
@@ -1,0 +1,3 @@
+args:
+- --kubelet-insecure-tls
+- --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname


### PR DESCRIPTION
Adds a `tidepool init-metrics-server` command that allows adding a metrics-server deployment to the local cluster to allow monitoring cpu and memory usage (in `k9s` for instance)

NOTE: after the command runs through, and each time the server starts up, it will take a minute or two before the metrics start showing up.