### PR TITLE
[WEB-75] Pass ROLLBAR_POST_SERVER_TOKEN build arg to blip

### DIFF
--- a/Tiltconfig.yaml
+++ b/Tiltconfig.yaml
@@ -110,6 +110,7 @@ blip:
   # hostPath: ../blip
   containerPath: '/app'
   apiHost: 'http://localhost:3000'
+  rollbarPostServerToken: '' # Rollbar post_server_item access token for posting source maps on production builds
   webpackDevTool: cheap-module-eval-source-map
   webpackDevToolViz: cheap-source-map # Suggest changing `cheap-source-map` to the slower, but far more helpful `source-map` if debugging errors in viz package files
   webpackPublicPath: 'http://localhost:3000'

--- a/Tiltfile
+++ b/Tiltfile
@@ -271,9 +271,12 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
               preBuildCommand += 'cd {hostPath} && rm -rf packageMounts/{packageName};'.format(
                 hostPath=hostPath,
                 packageName=packageName,
-              );
+              )
 
-        buildCommand += ' --build-arg LINKED_PKGS={}'.format(','.join(activeLinkedPackages))
+        buildCommand += ' --build-arg LINKED_PKGS={linkedPackages} --build-arg ROLLBAR_POST_SERVER_TOKEN={rollbarPostServerToken}'.format(
+          linkedPackages=','.join(activeLinkedPackages),
+          rollbarPostServerToken=overrides.get('rollbarPostServerToken'),
+        )
 
       buildCommand += ' {}'.format(hostPath)
 
@@ -285,7 +288,7 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
       if overrides.get('restartContainer', True):
         run_commands.append(restart_container())
 
-      live_update_commands = fallback_commands + sync_commands + run_commands;
+      live_update_commands = fallback_commands + sync_commands + run_commands
 
       custom_build(
         ref=getNested(overrides, 'deployment.image'),


### PR DESCRIPTION
Allows passing ROLLBAR_POST_SERVER_TOKEN to the blip docker build to enable source maps to be uploaded via webpack plugin

See [WEB-75]

[WEB-75]: https://tidepool.atlassian.net/browse/WEB-75