### PR TITLE
Fix chart generation

### DIFF
--- a/Tiltconfig.yaml
+++ b/Tiltconfig.yaml
@@ -3,7 +3,6 @@
 # parameters, and update the `hostPath` if you've checked the repo out to a different location.
 
 ### Global Config Start ###
-tidepool_helm_charts_version: '0.1.7' # Version of the Tidepool helm charts to deploy.
 
 global:
   gateway:

--- a/Tiltfile
+++ b/Tiltfile
@@ -5,8 +5,7 @@ tidepool_helm_overrides_file = getHelmOverridesFile()
 config = getConfig()
 watch_file(tidepool_helm_overrides_file)
 
-tidepool_helm_charts_version = config.get('tidepool_helm_charts_version')
-tidepool_helm_chart_dir = "./charts/tidepool/{}".format(tidepool_helm_charts_version)
+tidepool_helm_chart_dir = "./charts/tidepool"
 
 is_shutdown = isShutdown()
 ### Config End ###

--- a/Tiltfile.gateway
+++ b/Tiltfile.gateway
@@ -5,8 +5,7 @@ tidepool_helm_overrides_file = getHelmOverridesFile()
 config = getConfig()
 watch_file(tidepool_helm_overrides_file)
 
-tidepool_helm_charts_version = config.get('tidepool_helm_charts_version')
-tidepool_helm_chart_dir = "./charts/tidepool/{}".format(tidepool_helm_charts_version)
+tidepool_helm_chart_dir = "./charts/tidepool"
 
 gloo_chart_dir = './local/charts'
 absolute_gloo_chart_dir = getAbsoluteDir(gloo_chart_dir)

--- a/bin/gen_random_secrets
+++ b/bin/gen_random_secrets
@@ -40,7 +40,7 @@ QUICKSTART_DIR=$(realpath ./tidepool-quickstart)
 git clone git@github.com:/tidepool-org/development >/dev/null 2>&1
 (cd development; git checkout k8s >/dev/null 2>&1)
 DEV_DIR=$(realpath development)
-CHART_DIR=$DEV_DIR/charts/tidepool/0.1.7
+CHART_DIR=$DEV_DIR/charts/tidepool
 
 # clone config repo
 git clone $remote >/dev/null 2>&1

--- a/bin/gen_templated_secrets
+++ b/bin/gen_templated_secrets
@@ -22,7 +22,7 @@ QUICKSTART_DIR=$(realpath ./tidepool-quickstart)
 git clone git@github.com:/tidepool-org/development >/dev/null 2>&1
 (cd development; git checkout k8s >/dev/null 2>&1)
 DEV_DIR=$(realpath development)
-CHART_DIR=$DEV_DIR/charts/tidepool/0.1.7
+CHART_DIR=$DEV_DIR/charts/tidepool
 
 # run template processor to create non-Tidepool services
 cd $QUICKSTART_DIR

--- a/charts/tidepool/charts/glooingress/values.yaml
+++ b/charts/tidepool/charts/glooingress/values.yaml
@@ -16,15 +16,18 @@ virtualServices:
     enabled: true                       # whether to accept HTTP requests
     redirect: false                     # whether to redirect HTTP requests to HTTPS
     labels: {}
+    options: {}
   https:
     name: https
     dnsNames: []                        # DNS names served with HTTPS
     enabled: false                      # whether to serve HTTPS
     hsts: false                         # whether to require Strict Transport Security
     labels: {}
+    options: {}
   httpInternal:
     name: http-internal
     labels: {}
+    options: {}
 gloo:
   enabled: false                        # whether to install the Gloo API Gateway control plane
   crds:                                 


### PR DESCRIPTION
This PR fixes 2 issues which resulted in errors from template generation in Linux (not sure if other OS are affected).

https://github.com/tidepool-org/development/pull/78 removed the versioning of tidepool charts and moved the latest version under "charts/tidepool". However, the Tiltfile and some of the helpers were not updated accordingly.

`glooingress` subchart template also fails, because of a missing "options" attribute in the values yaml file. Most likely this is a regression introduced by https://github.com/tidepool-org/development/pull/82 