### PR TITLE
[WEB-728] Optimize mounted yarn installs in docker image builds

### DIFF
--- a/.tiltignore
+++ b/.tiltignore
@@ -13,8 +13,7 @@ coverage
 tmp
 web
 *.log
-*/packageMounts/*
-*/packageMountDeps/*
+packageMounts
 local/*
 !local/Tiltconfig.yaml
 package.json

--- a/.tiltignore
+++ b/.tiltignore
@@ -13,7 +13,8 @@ coverage
 tmp
 web
 *.log
-*/packageMounts
-*/packageMountDeps
+*/packageMounts/*
+*/packageMountDeps/*
 local/*
 !local/Tiltconfig.yaml
+package.json

--- a/README.md
+++ b/README.md
@@ -216,19 +216,13 @@ Once you've completed the [Initial Setup](#initial-setup), getting the Tidepool 
 
 ## With The Tidepool Helper Script (recommended)
 
-### Start the kubernetes server
+### Start the kubernetes server and store the Kubernetes server config locally
 
 ```bash
-tidepool server-start
+tidepool server-init
 ```
 
-### Retrieve and store the Kubernetes server config
-
-```bash
-tidepool server-set-config
-```
-
-This will save the Kubernetes server config to `~/.kube/config`. This is only required after the initial server start provisioning.
+This will save the Kubernetes server config to `~/.kube/config`. This is only required for the initial server provisioning.
 
 ### Start the tidepool services
 

--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ Managing a K8s cluster can be very challenging, and even more so when using one 
 
 By using our Tilt setup, developers can very easily run a live-reloading instance of any of our frontend or backend services without needing to directly use or understand Helm or Kubernetes. All that's needed is uncommenting a couple of lines in a `Tiltconfig.yaml` file, and updating the local paths to where the developer has checked out the respective git repo, if different than the default defined in the config.
 
-**IMPORTANT NOTE:** We currently run against version `v0.11.0` of Tilt, so be sure to install the correct version when following the [Tilt Installation Instructions](https://docs.tilt.dev/install.html#alternative-installation).
+**IMPORTANT NOTE:** We currently run against version `v0.11.4` of Tilt, so be sure to install the correct version when following the [Tilt Installation Instructions](https://docs.tilt.dev/install.html#alternative-installation).
 
 ```bash
 # MacOS
-curl -fsSL https://github.com/windmilleng/tilt/releases/download/v0.11.0/tilt.0.11.0.mac.x86_64.tar.gz | tar -xzv tilt && sudo mv tilt /usr/local/bin/tilt
+curl -fsSL https://github.com/windmilleng/tilt/releases/download/v0.11.4/tilt.0.11.4.mac.x86_64.tar.gz | tar -xzv tilt && sudo mv tilt /usr/local/bin/tilt
 
 # Linux
-curl -fsSL https://github.com/windmilleng/tilt/releases/download/v0.11.0/tilt.0.11.0.linux.x86_64.tar.gz | tar -xzv tilt && sudo mv tilt /usr/local/bin/tilt
+curl -fsSL https://github.com/windmilleng/tilt/releases/download/v0.11.4/tilt.0.11.4.linux.x86_64.tar.gz | tar -xzv tilt && sudo mv tilt /usr/local/bin/tilt
 ```
 
 After installing Tilt, you can verify the correct version by typing `tilt version` in your terminal.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Of course, if you haven't already done so, you should check out [Tidepool](https
   - [With The Tidepool Helper Script (recommended)](#with-the-tidepool-helper-script-recommended)
   - [Without The Tidepool Helper Script](#without-the-tidepool-helper-script)
   - [Monitor Kubernetes State With K9s (Optional)](#monitor-kubernetes-state-with-k9s-optional)
-  - [Add CPU/MEM Usage Metrics (Optional)](#add-cpumem-usage-metrics-optional)
 - [Using Tidepool](#using-tidepool)
   - [Creating An Account](#creating-an-account)
   - [Verifying An Account Email](#verifying-an-account-email)
@@ -307,27 +306,13 @@ docker-compose -f 'docker-compose.k8s.yml' stop
 
 While the tilt terminal UI shows a good deal of information, there may be times as a developer that you want a little deeper insight into what's happening inside Kubernetes.
 
-[K9s](https://k9ss.io/) is a CLI tool that provides a terminal UI to interact with your Kubernetes clusters.  It allows you to view in realtime the status of your Kubernetes pods and services without needing to learn the intricacies of `kubectl`, the powerful-but-complex Kubernetes CLI tool.
+[K9s](https://k9ss.io/) is a CLI tool that provides a terminal UI to interact with your Kubernetes clusters.  It allows you to view in realtime the status of your Kubernetes pods and services, including CPU and memory usage metrics, without needing to learn the intricacies of `kubectl`, the powerful-but-complex Kubernetes CLI tool.
 
 After [Installing the k9s CLI](https://github.com/derailed/k9s#installation), you can simply start the Terminal UI with:
 
 ```bash
 k9s
 ```
-
-## Add CPU/MEM Usage Metrics (Optional)
-
-If you would like to see metrics for CPU and Memory usage in, for instance, the K9s UI, you'll need to install the kubernetes `metrics-server` service.
-
-This can be done with the `tidepool` helper script:
-
-```bash
-tidepool server-init-metrics
-```
-
-This only needs to be run once. After the running the command, and each time the server starts up, it will take a minute or two before the metrics start showing up.
-
-If you're running the K9s UI during the initial deployment, you'll need to restart it to see the metrics coming in.
 
 [[back to top]](#welcome)
 

--- a/Tiltconfig.yaml
+++ b/Tiltconfig.yaml
@@ -115,6 +115,11 @@ blip:
   webpackPublicPath: 'http://localhost:3000'
   disableDevTools: false # Suggest changing to `true` if working with large data sets in local development build
   linkedPackages:
+    - name: viz
+      packageName: '@tidepool/viz'
+      hostPath: ../viz
+      enabled: false
+
     - name: tideline
       packageName: tideline
       hostPath: ../tideline
@@ -123,11 +128,6 @@ blip:
     - name: tidepool-platform-client
       packageName: tidepool-platform-client
       hostPath: ../platform-client
-      enabled: false
-
-    - name: viz
-      packageName: '@tidepool/viz'
-      hostPath: ../viz
       enabled: false
   securityContext: *global-security-context
   buildTarget: development # set to `production` to run minified production builds

--- a/Tiltfile
+++ b/Tiltfile
@@ -218,7 +218,6 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
         'cd {} && yarn install --silent'.format(containerPath),
         trigger=[
           '{}/yarn.lock'.format(hostPath),
-          '{}/package.json'.format(hostPath),
         ]
       ))
 
@@ -256,7 +255,6 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
               'cd /app/packageMounts/{} && yarn install --silent'.format(packageName),
               trigger=[
                 '{}/yarn.lock'.format(packageHostPath),
-                '{}/package.json'.format(packageHostPath),
               ]
             ))
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -215,10 +215,10 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
 
       # Run yarn install in container whenever yarn.lock changes on host
       run_commands.append(run(
-        'cd {} && yarn install --silent'.format(containerPath),
+        'cd {} && yarn install --silent --cache-folder .'.format(containerPath),
         trigger=[
           '{}/yarn.lock'.format(hostPath),
-          '{}/package-lock.json'.format(hostPath),
+          '{}/package.json'.format(hostPath),
         ]
       ))
 
@@ -253,8 +253,11 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
 
             # Run yarn install in linked package directory when it's yarn.lock changes
             run_commands.append(run(
-              'cd /app/packageMounts/{} && yarn install --silent'.format(packageName),
-              trigger='{}/yarn.lock'.format(packageHostPath),
+              'cd /app/packageMounts/{} && yarn install --silent --cache-folder .'.format(packageName),
+              trigger=[
+                '{}/yarn.lock'.format(packageHostPath),
+                '{}/package.json'.format(packageHostPath),
+              ]
             ))
 
             if not is_shutdown:

--- a/Tiltfile
+++ b/Tiltfile
@@ -215,7 +215,7 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
 
       # Run yarn install in container whenever yarn.lock changes on host
       run_commands.append(run(
-        'cd {} && yarn install --silent --cache-folder .'.format(containerPath),
+        'cd {} && yarn install --silent'.format(containerPath),
         trigger=[
           '{}/yarn.lock'.format(hostPath),
           '{}/package.json'.format(hostPath),
@@ -253,7 +253,7 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
 
             # Run yarn install in linked package directory when it's yarn.lock changes
             run_commands.append(run(
-              'cd /app/packageMounts/{} && yarn install --silent --cache-folder .'.format(packageName),
+              'cd /app/packageMounts/{} && yarn install --silent'.format(packageName),
               trigger=[
                 '{}/yarn.lock'.format(packageHostPath),
                 '{}/package.json'.format(packageHostPath),

--- a/Tiltfile
+++ b/Tiltfile
@@ -197,7 +197,7 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
       run_commands = []
       build_deps = [hostPath]
 
-      buildCommand = 'docker build --file {dockerFile} -t $EXPECTED_REF'.format(
+      buildCommand = 'DOCKER_BUILDKIT=1 docker build --file {dockerFile} -t $EXPECTED_REF'.format(
         dockerFile='{}/{}'.format(hostPath, dockerFile),
         target=target,
       )
@@ -259,7 +259,7 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
 
             if not is_shutdown:
               # Copy the package source into the Dockerfile build context
-              preBuildCommand += 'cd {hostPath} && mkdir -p packageMounts/{packageName} && rsync -a --delete --exclude "node_modules" --exclude ".git" --exclude "dist" --exclude "coverage" {packageHostPath}/ {hostPath}/packageMounts/{packageName};'.format(
+              preBuildCommand += 'cd {hostPath} && mkdir -p packageMounts/{packageName} && rsync -a --delete --exclude "node_modules" --exclude "stub" --exclude ".git" --exclude "dist" --exclude "coverage" {packageHostPath}/ {hostPath}/packageMounts/{packageName};'.format(
                 hostPath=hostPath,
                 packageHostPath=packageHostPath,
                 packageName=packageName,
@@ -268,7 +268,7 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
           else:
             if not is_shutdown:
               # Remove the package source from the Dockerfile build context
-              preBuildCommand += 'cd {hostPath} && rm -rf packageMounts/{packageName};'.format(
+              preBuildCommand += 'cd {hostPath}/packageMounts/{packageName} && find . -type f -not -name \'stub\' -delete && find . -type d -empty -delete;'.format(
                 hostPath=hostPath,
                 packageName=packageName,
               );

--- a/Tiltfile
+++ b/Tiltfile
@@ -215,7 +215,7 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
 
       # Run yarn install in container whenever yarn.lock changes on host
       run_commands.append(run(
-        'cd {} && yarn install --silent'.format(containerPath),
+        'cd {} && yarn install --silent --no-progress'.format(containerPath),
         trigger=[
           '{}/yarn.lock'.format(hostPath),
         ]
@@ -252,7 +252,7 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
 
             # Run yarn install in linked package directory when it's yarn.lock changes
             run_commands.append(run(
-              'cd /app/packageMounts/{} && yarn install --silent'.format(packageName),
+              'cd /app/packageMounts/{} && yarn install --silent --no-progress'.format(packageName),
               trigger=[
                 '{}/yarn.lock'.format(packageHostPath),
               ]

--- a/bin/tidepool
+++ b/bin/tidepool
@@ -186,7 +186,7 @@ case ${1-help} in
   server-exec) (cd ${DIR} && run_docker_compose exec server sh);;
   server-prune) (run_docker "system prune --volumes -af");;
   server-destroy) (cd ${DIR} && destroy);;
-  start) (cd ${DIR} && set_tilt_env --trap-shutdown && tilt up --port=0 ${2-});;
+  start) (cd ${DIR} && set_tilt_env --trap-shutdown && tilt up -dv --port=0 ${2-});;
   stop) (cd ${DIR} && set_tilt_env --shutdown && tilt down);;
   restart) restart ${2-};;
   logs) (cd ${DIR} && kubectl logs svc/${2} --tail=100 -c ${2} -f);;

--- a/bin/tidepool
+++ b/bin/tidepool
@@ -20,9 +20,6 @@ USAGE: tidepool command [service] [...additional args]
   server-stop                     Stop the Kubernetes server
   server-logs                     Tail logs for the Kubernetes server
 
-  server-set-config               Save Kubernetes server config to ~/.kube/config. Required only
-                                  after the initial provisioning
-
   server-docker [...cmds]         Run docker commands within the context of the Kubernetes server
   server-exec [...cmds]           Run shell commands in the Kubernetes server container
 
@@ -189,11 +186,10 @@ init_metrics_server() {
 }
 
 case ${1-help} in
+  server-init) server_init;;
   server-start) (cd ${DIR} && run_docker_compose up -d ${2-});;
   server-stop) (cd ${DIR} && run_docker_compose stop ${2-});;
   server-logs) (cd ${DIR} && run_docker_compose logs --tail=100 -f server);;
-  server-set-config) set_kubeconfig;;
-  server-init) server_init;;
   server-docker) run_docker "${@:2}";;
   server-exec) (cd ${DIR} && run_docker_compose exec server sh);;
   server-prune) (run_docker "system prune --volumes -af" && run_docker "builder prune --all -f");;

--- a/bin/tidepool
+++ b/bin/tidepool
@@ -170,11 +170,6 @@ server_init() {
   init_metrics_server
 }
 
-server_set_experimental() {
-  # Set docker to experimental mode
-  cd ${DIR} && docker-compose -f 'docker-compose.k8s.yml' exec server sh -c "if ! grep -qF '\"experimental\": true' /etc/docker/daemon.json; then echo $'{\n    \"experimental\": true\n}' | sudo tee /etc/docker/daemon.json; fi"
-}
-
 init_metrics_server() {
     cd ${DIR} && docker-compose -f 'docker-compose.k8s.yml' exec server sh -c "if ! grep -qF 'authentication-token-webhook=true' kubelet.sh; then sed -i '/--authorization-mode=Webhook/a --authentication-token-webhook=true \\\' kubelet.sh; fi"
 

--- a/bin/tidepool
+++ b/bin/tidepool
@@ -11,15 +11,17 @@ USAGE: tidepool command [service] [...additional args]
 
   ### Kubernetes Server Commands ###
 
+  server-init                     Used once to initially provision the k8s stack. Specifically, it:
+                                    1. Provisions and starts the Kubernetes server
+                                    2. Saves the Kubernetes server config to ~/.kube/config.
+                                    3. Deploys metrics-server to monitor CPU and MEM usage for resources
+
   server-start                    Start (and provision if needed) the Kubernetes server
   server-stop                     Stop the Kubernetes server
   server-logs                     Tail logs for the Kubernetes server
 
   server-set-config               Save Kubernetes server config to ~/.kube/config. Required only
                                   after the initial provisioning
-
-  server-init-metrics             Initializes a metrics-server deployment to allow viewing CPU and
-                                  MEM usage metrics for all cluster resources
 
   server-docker [...cmds]         Run docker commands within the context of the Kubernetes server
   server-exec [...cmds]           Run shell commands in the Kubernetes server container

--- a/bin/tidepool
+++ b/bin/tidepool
@@ -103,7 +103,7 @@ doctor() {
   set +u
   echo "Checking dependancy versions..."
   check_version helm 'version --short' 3.0.2
-  check_version tilt 'version' 0.11.0
+  check_version tilt 'version' 0.11.4
   check_version docker '-v' 19.0.0
   check_version docker-compose '-v' 1.25.0
   check_version kubectl 'version --client --short' 1.15.1
@@ -139,10 +139,14 @@ set_tilt_env() {
   esac
 }
 
-set_kubeconfig() {
+wait_for_kubernetes_ready() {
   until curl -s --fail http://127.0.0.1:10080/kubernetes-ready; do
     sleep 1;
   done
+}
+
+set_kubeconfig() {
+  wait_for_kubernetes_ready
   curl http://127.0.0.1:10080/config > ~/.kube/config
 }
 
@@ -158,15 +162,26 @@ destroy() {
   fi
 }
 
+server_init() {
+  $0 server-start
+  set_kubeconfig
+  init_metrics_server
+}
+
+server_set_experimental() {
+  # Set docker to experimental mode
+  cd ${DIR} && docker-compose -f 'docker-compose.k8s.yml' exec server sh -c "if ! grep -qF '\"experimental\": true' /etc/docker/daemon.json; then echo $'{\n    \"experimental\": true\n}' | sudo tee /etc/docker/daemon.json; fi"
+}
+
 init_metrics_server() {
     cd ${DIR} && docker-compose -f 'docker-compose.k8s.yml' exec server sh -c "if ! grep -qF 'authentication-token-webhook=true' kubelet.sh; then sed -i '/--authorization-mode=Webhook/a --authentication-token-webhook=true \\\' kubelet.sh; fi"
 
     # Restart the server and wait till ready
     cd ${DIR} && run_docker_compose restart
-    set_kubeconfig
+    wait_for_kubernetes_ready
 
     # Wait until kubectl ready
-    until kubectl cluster-info; do
+    until kubectl get nodes; do
       sleep 5;
     done
 
@@ -181,7 +196,7 @@ case ${1-help} in
   server-stop) (cd ${DIR} && run_docker_compose stop ${2-});;
   server-logs) (cd ${DIR} && run_docker_compose logs --tail=100 -f server);;
   server-set-config) set_kubeconfig;;
-  server-init-metrics) init_metrics_server;;
+  server-init) server_init;;
   server-docker) run_docker "${@:2}";;
   server-exec) (cd ${DIR} && run_docker_compose exec server sh);;
   server-prune) (run_docker "system prune --volumes -af");;

--- a/bin/tidepool
+++ b/bin/tidepool
@@ -199,7 +199,7 @@ case ${1-help} in
   server-init) server_init;;
   server-docker) run_docker "${@:2}";;
   server-exec) (cd ${DIR} && run_docker_compose exec server sh);;
-  server-prune) (run_docker "system prune --volumes -af");;
+  server-prune) (run_docker "system prune --volumes -af" && run_docker "builder prune --all -f");;
   server-destroy) (cd ${DIR} && destroy);;
   start) (cd ${DIR} && set_tilt_env --trap-shutdown && tilt up -dv --port=0 ${2-});;
   stop) (cd ${DIR} && set_tilt_env --shutdown && tilt down);;

--- a/docker-compose.k8s.yml
+++ b/docker-compose.k8s.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   server:
-    image: tidepool/kind:latest
+    image: tidepool/kind:1.14.8
     privileged: true
     network_mode: bridge
     ports:

--- a/docker-compose.k8s.yml
+++ b/docker-compose.k8s.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   server:
-    image: bsycorp/kind:v1.15.1
+    image: tidepool/kind:latest
     privileged: true
     network_mode: bridge
     ports:


### PR DESCRIPTION
See [WEB-728] for details

Uses a custom image for the KIND server, since the bsycorp/kind images didn't use the latest Docker version to properly support building with Buildkit enabled in the Tiltfile, nor did the K8s version match what we use in production.

The image was built with a fork of the `bsycorp/kind` repo.  There was some additional work to be done in order to run the latest version of Docker (with BuildKit fully integrated) in the KIND stack.  I did issue a PR which has been merged into the upstream, so we won't need to maintain this fork, and can always build a new base KIND image from the upstream repo as per the README instructions.  

In addition, if it's preferable, we could use the new `bsycorp/kind:v1.14.10` image which is pretty close to our k8s version (`1.14.8`), since that image was build after the PR was merged, and is running the Docker version we need.

For reference, here is the PR: https://github.com/bsycorp/kind/pull/28

Also, I've added a `tidepool server-init` script to automatically store the kube config locally and install the metrics server on initial provisioning, as well as making a few changes to the Tiltfile and .tiltignore to optimize the yarn install processes.

Related PRs:
---
tidepool-org/tools#81
tidepool-org/blip#655

[WEB-728]: https://tidepool.atlassian.net/browse/WEB-728