### PR TITLE
Add Pod Disruption Budgets only when replicas are above 1

### DIFF
--- a/charts/tidepool/charts/auth/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/auth/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: auth
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: auth
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/auth/values.yaml
+++ b/charts/tidepool/charts/auth/values.yaml
@@ -18,6 +18,7 @@ podAnnotations: {}
 securityContext: {}
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/blip/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/blip/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: blip
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: blip
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/blip/values.yaml
+++ b/charts/tidepool/charts/blip/values.yaml
@@ -8,6 +8,7 @@ podAnnotations: {}
 securityContext: {}
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/blob/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/blob/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: blob
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: blob
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/blob/values.yaml
+++ b/charts/tidepool/charts/blob/values.yaml
@@ -23,6 +23,7 @@ serviceAccount:
   create: false
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/data/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/data/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: data
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: data
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/data/values.yaml
+++ b/charts/tidepool/charts/data/values.yaml
@@ -11,6 +11,7 @@ podAnnotations: {}
 securityContext: {}
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/export/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/export/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: export
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: export
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/export/values.yaml
+++ b/charts/tidepool/charts/export/values.yaml
@@ -11,6 +11,7 @@ podAnnotations: {}
 securityContext: {}
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/gatekeeper/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/gatekeeper/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: gatekeeper
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: gatekeeper
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/gatekeeper/values.yaml
+++ b/charts/tidepool/charts/gatekeeper/values.yaml
@@ -5,9 +5,10 @@ resources: {}
 podSecurityContext: {}
 podAnnotations: {}
 securityContext: {}
+nodeEnvironment: production
 hpa:
   enabled: false
-nodeEnvironment: production
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/highwater/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/highwater/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: highwater
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: highwater
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/highwater/values.yaml
+++ b/charts/tidepool/charts/highwater/values.yaml
@@ -5,9 +5,10 @@ resources: {}
 podSecurityContext: {}
 podAnnotations: {}
 securityContext: {}
+nodeEnvironment: production
 hpa:
   enabled: false
-nodeEnvironment: production
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/hydrophone/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/hydrophone/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: hydrophone
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: hydrophone
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/hydrophone/values.yaml
+++ b/charts/tidepool/charts/hydrophone/values.yaml
@@ -14,6 +14,7 @@ serviceAccount:
   create: false
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/image/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/image/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: image
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: image
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/image/values.yaml
+++ b/charts/tidepool/charts/image/values.yaml
@@ -24,6 +24,7 @@ serviceAccount:
   create: false
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/jellyfish/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/jellyfish/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: jellyfish
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: jellyfish
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/jellyfish/values.yaml
+++ b/charts/tidepool/charts/jellyfish/values.yaml
@@ -15,6 +15,7 @@ serviceAccount:
   create: false
 hpa:
   enabled: false
+  minReplicas: 1
 nodeEnvironment: production
 pdb:
   enabled: false

--- a/charts/tidepool/charts/messageapi/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/messageapi/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: messageapi
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: message-api
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/messageapi/values.yaml
+++ b/charts/tidepool/charts/messageapi/values.yaml
@@ -7,9 +7,10 @@ resources: {}
 podSecurityContext: {}
 podAnnotations: {}
 securityContext: {}
+nodeEnvironment: production
 hpa:
   enabled: false
-nodeEnvironment: production
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/notification/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/notification/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: notification
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: notification
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/notification/values.yaml
+++ b/charts/tidepool/charts/notification/values.yaml
@@ -11,6 +11,7 @@ podAnnotations: {}
 securityContext: {}
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/prescription/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/prescription/templates/6-pdb.yaml
@@ -1,14 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: prescription
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Namespace }}
-      app.kubernetes.io/name: prescription
+      app: {{ include "charts.name" . }}
+      app.kubernetes.io/name: {{ include "charts.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/prescription/values.yaml
+++ b/charts/tidepool/charts/prescription/values.yaml
@@ -14,6 +14,7 @@ resources: {}
 securityContext: {}
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/seagull/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/seagull/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: seagull
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: seagull
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/seagull/values.yaml
+++ b/charts/tidepool/charts/seagull/values.yaml
@@ -5,9 +5,10 @@ resources: {}
 podSecurityContext: {}
 podAnnotations: {}
 securityContext: {}
+nodeEnvironment: production
 hpa:
   enabled: false
-nodeEnvironment: production
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/shoreline/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/shoreline/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: shoreline
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: shoreline
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/shoreline/values.yaml
+++ b/charts/tidepool/charts/shoreline/values.yaml
@@ -20,6 +20,7 @@ serviceMonitor:
   enabled: false
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/task/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/task/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: task
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: task
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/task/values.yaml
+++ b/charts/tidepool/charts/task/values.yaml
@@ -15,6 +15,7 @@ podAnnotations: {}
 securityContext: {}
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/tidewhisperer/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/tidewhisperer/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: tidewhisperer
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: tide-whisperer
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/tidewhisperer/values.yaml
+++ b/charts/tidepool/charts/tidewhisperer/values.yaml
@@ -7,6 +7,7 @@ podAnnotations: {}
 securityContext: {}
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1

--- a/charts/tidepool/charts/user/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/user/templates/6-pdb.yaml
@@ -1,15 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.controller.hpa.enabled (gt (.Values.controller.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: user
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
-      app: user
+      app: {{ include "charts.name" . }}
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/user/values.yaml
+++ b/charts/tidepool/charts/user/values.yaml
@@ -11,6 +11,7 @@ podAnnotations: {}
 securityContext: {}
 hpa:
   enabled: false
+  minReplicas: 1
 pdb:
   enabled: false
   minAvailable: 1


### PR DESCRIPTION
Otherwise it'll lock down nodes.

Example: https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml