### PR TITLE
Increase failure thresholds for export

### DIFF
--- a/charts/tidepool/charts/export/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/export/templates/1-deployment.yaml
@@ -64,8 +64,9 @@ spec:
             path: /export/status
             port: {{ .Values.global.ports.export }}
           initialDelaySeconds: 30
+          failureThreshold: 6
           periodSeconds: 10
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: export
         ports:
         - containerPort: {{.Values.global.ports.export}}


### PR DESCRIPTION
Increase the failure threshold, now it'll be 6 attempts every 10 seconds instead of 3 x 10 seconds. It would make the liveness probing period longer. So, export would cancel the request itself instead of Kubernetes restarting the pod and when it's cancelled CPU will drop and the liveness probes should be back to normal, might get more complex with multiple very large requests.