### PR TITLE
Use 50% as the default for PDB's minAvailable

### DIFF
--- a/charts/tidepool/charts/auth/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/auth/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/auth/values.yaml
+++ b/charts/tidepool/charts/auth/values.yaml
@@ -21,7 +21,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/blip/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/blip/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/blip/values.yaml
+++ b/charts/tidepool/charts/blip/values.yaml
@@ -11,7 +11,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/charts/tidepool/charts/blob/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/blob/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/blob/values.yaml
+++ b/charts/tidepool/charts/blob/values.yaml
@@ -26,7 +26,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/data/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/data/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/data/values.yaml
+++ b/charts/tidepool/charts/data/values.yaml
@@ -14,7 +14,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/devices/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/devices/templates/6-pdb.yaml
@@ -1,14 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.hpa.enabled (gt (.Values.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: devices
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Namespace }}
-      app.kubernetes.io/name: devices
+      app: {{ include "charts.name" . }}
+      app.kubernetes.io/name: {{ include "charts.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/devices/values.yaml
+++ b/charts/tidepool/charts/devices/values.yaml
@@ -8,7 +8,7 @@ hpa:
   enabled: false
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/charts/tidepool/charts/export/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/export/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/export/values.yaml
+++ b/charts/tidepool/charts/export/values.yaml
@@ -16,7 +16,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/gatekeeper/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/gatekeeper/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/gatekeeper/values.yaml
+++ b/charts/tidepool/charts/gatekeeper/values.yaml
@@ -11,7 +11,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/highwater/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/highwater/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/highwater/values.yaml
+++ b/charts/tidepool/charts/highwater/values.yaml
@@ -11,7 +11,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/hydrophone/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/hydrophone/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/hydrophone/values.yaml
+++ b/charts/tidepool/charts/hydrophone/values.yaml
@@ -17,7 +17,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/image/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/image/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/image/values.yaml
+++ b/charts/tidepool/charts/image/values.yaml
@@ -27,7 +27,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/jellyfish/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/jellyfish/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/jellyfish/values.yaml
+++ b/charts/tidepool/charts/jellyfish/values.yaml
@@ -19,7 +19,7 @@ hpa:
 nodeEnvironment: production
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/messageapi/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/messageapi/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/messageapi/values.yaml
+++ b/charts/tidepool/charts/messageapi/values.yaml
@@ -13,7 +13,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/migrations/templates/migrations-pdb.yaml
+++ b/charts/tidepool/charts/migrations/templates/migrations-pdb.yaml
@@ -1,14 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.hpa.enabled (gt (.Values.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: migrations
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Namespace }}
-      app.kubernetes.io/name: migrations
+      app: {{ include "charts.name" . }}
+      app.kubernetes.io/name: {{ include "charts.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/migrations/values.yaml
+++ b/charts/tidepool/charts/migrations/values.yaml
@@ -10,7 +10,7 @@ hpa:
   enabled: false
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/notification/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/notification/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/notification/values.yaml
+++ b/charts/tidepool/charts/notification/values.yaml
@@ -14,7 +14,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/prescription/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/prescription/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/prescription/values.yaml
+++ b/charts/tidepool/charts/prescription/values.yaml
@@ -17,7 +17,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/seagull/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/seagull/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/seagull/values.yaml
+++ b/charts/tidepool/charts/seagull/values.yaml
@@ -11,7 +11,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/shoreline/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/shoreline/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/shoreline/values.yaml
+++ b/charts/tidepool/charts/shoreline/values.yaml
@@ -23,7 +23,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/task/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/task/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/task/values.yaml
+++ b/charts/tidepool/charts/task/values.yaml
@@ -18,7 +18,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/tidewhisperer/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/tidewhisperer/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: tide-whisperer

--- a/charts/tidepool/charts/tidewhisperer/values.yaml
+++ b/charts/tidepool/charts/tidewhisperer/values.yaml
@@ -10,7 +10,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/tools/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/tools/templates/6-pdb.yaml
@@ -1,14 +1,17 @@
 {{ if .Values.pdb.enabled }}
+{{- if or (and .Values.hpa.enabled (gt (.Values.hpa.minReplicas | int) 1)) (gt (.Values.deployment.replicas | int) 1) -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: tools
+  name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Namespace }}
-      app.kubernetes.io/name: tools
+      app: {{ include "charts.name" . }}
+      app.kubernetes.io/name: {{ include "charts.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}
 {{ end }}

--- a/charts/tidepool/charts/tools/values.yaml
+++ b/charts/tidepool/charts/tools/values.yaml
@@ -10,7 +10,7 @@ hpa:
   enabled: false
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}

--- a/charts/tidepool/charts/user/templates/6-pdb.yaml
+++ b/charts/tidepool/charts/user/templates/6-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "charts.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:
       app: {{ include "charts.name" . }}

--- a/charts/tidepool/charts/user/values.yaml
+++ b/charts/tidepool/charts/user/values.yaml
@@ -14,7 +14,7 @@ hpa:
   minReplicas: 1
 pdb:
   enabled: false
-  minAvailable: 1
+  minAvailable: "50%"
 mongo:
   secretName: mongo
 nodeSelector: {}


### PR DESCRIPTION
Since PDBs are immutable and we use helm charts to upgrade deploys it becomes a manual action to remove the PDB before deployment, therefore I'd like to adjust them as little as possible for all envs except for production. I think 50% is a more sane default and it will work better with services that run more replicas e.g Tidewhisperer with 6. Also, when using HPAs this will adjust automatically to the scaled replicas by the HPA. It will always round upwards. E.g 7 replicas, 4 need to be available at the minimum.

WDYT @derrickburns?