### PR TITLE
Add missing serviceMonitor key to export helm chart values

### DIFF
--- a/charts/tidepool/charts/export/values.yaml
+++ b/charts/tidepool/charts/export/values.yaml
@@ -9,6 +9,8 @@ resources: {}
 podSecurityContext: {}
 podAnnotations: {}
 securityContext: {}
+serviceMonitor:
+  enabled: false
 hpa:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
Noticed this was missing when I went to run the latest master branch in my local k8s cluster