### PR TITLE
[WEB-984] Set Tilt to use the root Tiltconfig.yaml, and only require overrides in local/Tiltconfig.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,15 +368,18 @@ Fortunately, at [Tidepool Web](https://app.tidepool.org), we worry about that fo
 
 ## Tilt Config Overrides
 
-Custom Tilt configuration and overrides of the Tidepool, MongoDB, and Gateway services is done through a local copy of the `Tiltconfig.yaml` file, which should be copied to `local/Tiltconfig.yaml` and updated there.
+Custom Tilt configuration and overrides of the Tidepool, MongoDB, and Gateway services is done through a `local/Tiltconfig.yaml` file.
 
-While updates can be made directly to the root `Tiltconfig.yaml` file,making your changes to the local copy ensures that they are made in a directory that's ignored by version control.
+While updates can be made directly to the root `Tiltconfig.yaml` file,making your changes to a local overrides file ensures that your changes are ignored by version control.
+
+It also means less work for you when pulling in upstream updates to the root config file.
 
 ```bash
-cp Tiltconfig.yaml local/Tiltconfig.yaml
+# Create an empty Tiltconfig.yaml file in your local directory
+touch local/Tiltconfig.yaml
 ```
 
-The overrides file is read by the `Tiltfile` (and `Tiltfile.mongodb` and `Tiltfile.proxy`) at the root of this repo, and any changes defined for the helm charts will be passed through to helm to override settings in the helm chart `values.yaml`.
+Both the root `Tiltconfig.yaml` and the overrides file is read by the `Tiltfile` (and `Tiltfile.mongodb` and `Tiltfile.proxy`) at the root of this repo, and any changes defined for the helm charts will be passed through to helm to override settings in the helm chart `values.yaml`.
 
 In addition to the helm chart overrides, there are some extra configuration parameters to instruct Tilt on how to build local images for any of the Tidepool services.
 
@@ -578,14 +581,14 @@ To build and run a Docker image from the source code you just cloned, you simply
 For instance, to have Tilt build a local image for `shoreline`:
 
 ```yaml
-### Change this:
+### Copy this service definition from the root Tiltconfig.yaml:
 shoreline:
   # deployment:
   #   image: tidepool-k8s-shoreline
   # hostPath: "~/go/src/github.com/tidepool-org/shoreline"
   # ...
 
-### To this:
+### Paste it into your local/Tiltconfig.yaml file and make your updates:
 shoreline:
   deployment:
     image: tidepool-k8s-shoreline

--- a/Tiltconfig.yaml
+++ b/Tiltconfig.yaml
@@ -1,4 +1,4 @@
-# Copy to `local/Tiltconfig.yaml` and update as needed
+# Create an empty `local/Tiltconfig.yaml` and copy over any other services and update as needed
 # To run local development images for the tidepool services, uncomment the `image` and `hostPath`
 # parameters, and update the `hostPath` if you've checked the repo out to a different location.
 
@@ -22,13 +22,6 @@ global:
     enabled: false
     templated: false
     generated: false
-  securityContext: &global-security-context
-    allowPrivilegeEscalation: false
-    runAsNonRoot: true
-    runAsUser: 1000
-    capabilities:
-      drop:
-      - ALL
 ### Global Config End ###
 
 ### Gateway Config Start ###
@@ -52,8 +45,8 @@ apiServer:
 ### MongoDB Config Start ###
 mongodb:
   persistent: true
-  enabled: false # False to disable the helm-chart-defined mongo, as we deploy our own directly within the Tiltfile
-  useExternal: false # Set to true and update the global mongo config below if using an external mongo db
+  enabled: false       # False to disable the helm-chart-defined mongo, as we deploy our own directly within the Tiltfile
+  useExternal: false   # Set to true and update the global mongo config below if using an external mongo db
   hostPath: '/data/db' # Note: this path is relative to the k8s server container defined in `docker-compose.k8s.yml`. Local machine path is volume-mounted using the TIDEPOOL_DOCKER_MONGO_VOLUME environment variable.
   portForwards: ['27017']
 
@@ -166,33 +159,30 @@ userdata:
   secret:
     enabled: false
     data_:
-      ServiceAuth: "This secret is used to encrypt the group id stored in the DB for gatekeeper" # Replaces previously used TIDEPOOL_DOCKER_GATEKEEPER_SECRET env variable
-      UserIdSalt: "This secret is used to salt the user id stored in the DB for highwater" # Replaces previously used TIDEPOOL_DOCKER_HIGHWATER_SALT env variable
+      ServiceAuth: "This secret is used to encrypt the group id stored in the DB for gatekeeper"   # Replaces previously used TIDEPOOL_DOCKER_GATEKEEPER_SECRET env variable
+      UserIdSalt: "This secret is used to salt the user id stored in the DB for highwater"         # Replaces previously used TIDEPOOL_DOCKER_HIGHWATER_SALT env variable
       PasswordSalt: "This secret is used to salt the user password stored in the DB for shoreline" # Replaces previously used TIDEPOOL_DOCKER_SHORELINE_SALT env variable
 ### User Data Secret Config Start ###
 
 ### Tidepool Services Config Start ###
 auth:
   deployment:
-    # image: tidepool-k8s-auth
-  # hostPath: ../platform
+    # image: tidepool-k8s-auth # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../platform      # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/platform'
   dockerFile: 'Dockerfile.auth'
   rebuildCommand: 'SERVICE=auth make service-build'
 
 blip:
   deployment:
-    # image: tidepool-k8s-blip
-  # hostPath: ../blip
+    # image: tidepool-k8s-blip # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../blip          # Uncomment to build and run local image
   containerPath: '/app'
   apiHost: 'http://localhost:3000'
   rollbarPostServerToken: '' # Rollbar post_server_item access token for posting source maps on production builds
-  i18nEnabled: 'false' # Feature flag to enable localization UI. Note must use 'true' or 'false'. Quotes mandatory.
-  rxEnabled: 'false' # Feature flag to enable prescriptions UI. Note must use 'true' or 'false'. Quotes mandatory.
   webpackDevTool: cheap-module-eval-source-map
   webpackDevToolViz: cheap-source-map # Suggest changing `cheap-source-map` to the slower, but far more helpful `source-map` if debugging errors in viz package files
   webpackPublicPath: 'http://localhost:3000/'
-  disableDevTools: false # Suggest changing to `true` if working with large data sets in local development build
   linkedPackages:
     - name: viz
       packageName: '@tidepool/viz'
@@ -208,22 +198,31 @@ blip:
       packageName: tidepool-platform-client
       hostPath: ../platform-client
       enabled: false
-  securityContext: *global-security-context
-  # buildTarget: production # Uncomment to run minified production builds
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1000
+    capabilities:
+      drop:
+      - ALL
+  # i18nEnabled: 'true'                                       # Uncomment to enable internationalization UI
+  # rxEnabled: 'true'                                         # Uncomment to enable prescriptions UI
+  # disableDevTools: true                                     # Uncomment if working with large data sets is sluggish in development build
+  # buildTarget: production                                   # Uncomment to run minified production builds
   # restartContainerCommand: './tilt/start.sh npm run server' # Uncomment if buildTarget = `production`
 
 blob:
   deployment:
-    # image: tidepool-k8s-blob
-  # hostPath: ../platform
+    # image: tidepool-k8s-blob # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../platform      # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/platform'
   dockerFile: 'Dockerfile.blob'
   rebuildCommand: 'SERVICE=blob make service-build'
 
 data:
   deployment:
-    # image: tidepool-k8s-data
-  # hostPath: ../platform
+    # image: tidepool-k8s-data # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../platform      # Uncomment to build and run local image
   containerPath: ../platform
   dockerFile: 'Dockerfile.data'
   rebuildCommand: 'SERVICE=data make service-build'
@@ -231,69 +230,69 @@ data:
 devices:
   deployment:
     replicas: 1
-    # image: tidepool-k8s-devices
-  # hostPath: '~/go/src/github.com/tidepool-org/devices'
+    # image: tidepool-k8s-devices                        # Uncomment to build and run local image or a specific remote image
+  # hostPath: '~/go/src/github.com/tidepool-org/devices' # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/devices'
   buildTarget: 'build'
   rebuildCommand: 'make generate && make build'
 
 export:
   deployment:
-    # image: tidepool-k8s-export
-  # hostPath: ../export
+    # image: tidepool-k8s-export # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../export          # Uncomment to build and run local image
   containerPath: '/app'
 
 gatekeeper:
   deployment:
-    # image: tidepool-k8s-gatekeeper
-  # hostPath: ../gatekeeper
+    # image: tidepool-k8s-gatekeeper # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../gatekeeper          # Uncomment to build and run local image
   containerPath: '/app'
 
 highwater:
   deployment:
-    # image: tidepool-k8s-highwater
-  # hostPath: ../highwater
+    # image: tidepool-k8s-highwater # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../highwater          # Uncomment to build and run local image
   containerPath: '/app'
 
 hydrophone:
   deployment:
-    # image: tidepool-k8s-hydrophone
-  # hostPath: ../hydrophone
+    # image: tidepool-k8s-hydrophone # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../hydrophone          # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/hydrophone'
   rebuildCommand: './build.sh'
 
 image:
   deployment:
-    # image: tidepool-k8s-image
-  # hostPath: ../platform
+    # image: tidepool-k8s-image # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../platform       # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/platform'
   dockerFile: 'Dockerfile.image'
   rebuildCommand: 'SERVICE=image make service-build'
 
 jellyfish:
   deployment:
-    # image: tidepool-k8s-jellyfish
-  # hostPath: ../jellyfish
+    # image: tidepool-k8s-jellyfish # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../jellyfish          # Uncomment to build and run local image
   containerPath: '/app'
 
 message-api:
   deployment:
-    # image: tidepool-k8s-message-api
-  # hostPath: ../message-api
+    # image: tidepool-k8s-message-api # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../message-api          # Uncomment to build and run local image
   containerPath: '/app'
 
 migrations:
   deployment:
-    # image: tidepool-k8s-migrations
-  # hostPath: ../platform
+    # image: tidepool-k8s-migrations # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../platform            # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/platform'
   dockerFile: 'Dockerfile.migrations'
   rebuildCommand: 'SERVICE=migrations make service-build'
 
 notification:
   deployment:
-    # image: tidepool-k8s-notification
-  # hostPath: ../platform
+    # image: tidepool-k8s-notification # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../platform              # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/platform'
   dockerFile: 'Dockerfile.notification'
   rebuildCommand: 'SERVICE=notification make service-build'
@@ -301,22 +300,22 @@ notification:
 prescription:
   deployment:
     replicas: 1
-    # image: tidepool-k8s-prescription
-  # hostPath: '~/go/src/github.com/tidepool-org/platform'
+    # image: tidepool-k8s-prescription                    # Uncomment to build and run local image or a specific remote image
+  # hostPath: '~/go/src/github.com/tidepool-org/platform' # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/platform'
   dockerFile: 'Dockerfile.prescription'
   rebuildCommand: 'SERVICE=prescription make service-build'
 
 seagull:
   deployment:
-    # image: tidepool-k8s-seagull
-  # hostPath: ../seagull
+    # image: tidepool-k8s-seagull # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../seagull          # Uncomment to build and run local image
   containerPath: '/app'
 
 shoreline:
   deployment:
-    # image: tidepool-k8s-shoreline
-  # hostPath: ../shoreline
+    # image: tidepool-k8s-shoreline # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../shoreline          # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/shoreline'
   rebuildCommand: './build.sh'
   configmap:
@@ -326,31 +325,31 @@ shoreline:
 
 task:
   deployment:
-    # image: tidepool-k8s-task
-  # hostPath: ../platform
+    # image: tidepool-k8s-task # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../platform      # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/platform'
   dockerFile: 'Dockerfile.task'
   rebuildCommand: 'SERVICE=task make service-build'
 
 tide-whisperer:
   deployment:
-    # image: tidepool-k8s-tide-whisperer
-  # hostPath: ../tide-whisperer
+    # image: tidepool-k8s-tide-whisperer # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../tide-whisperer          # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/tide-whisperer'
   rebuildCommand: './build.sh'
 
 tools:
   deployment:
-    # image: tidepool-k8s-tools
-  # hostPath: ../platform
+    # image: tidepool-k8s-tools # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../platform       # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/platform'
   dockerFile: 'Dockerfile.tools'
   rebuildCommand: 'SERVICE=tools make service-build'
 
 user:
   deployment:
-    # image: tidepool-k8s-user
-  # hostPath: ../platform
+    # image: tidepool-k8s-user # Uncomment to build and run local image or a specific remote image
+  # hostPath: ../platform      # Uncomment to build and run local image
   containerPath: '/go/src/github.com/tidepool-org/platform'
   dockerFile: 'Dockerfile.user'
   rebuildCommand: 'SERVICE=user make service-build'

--- a/Tiltfile.gateway
+++ b/Tiltfile.gateway
@@ -1,10 +1,13 @@
-load('./Tiltfile.global', 'getAbsoluteDir', 'getNested', 'getConfig', 'getHelmOverridesFile', 'isShutdown')
+load('./Tiltfile.global', 'getAbsoluteDir', 'getNested', 'getConfig', 'getHelmValuesFile', 'getHelmOverridesFile', 'isShutdown')
 
 allow_k8s_contexts('kind-admin@mk')
 
 ### Config Start ###
+tidepool_helm_values_file = getHelmValuesFile()
 tidepool_helm_overrides_file = getHelmOverridesFile()
 config = getConfig()
+
+watch_file(tidepool_helm_values_file)
 watch_file(tidepool_helm_overrides_file)
 
 local_helm_chart_dir = './local/charts'
@@ -99,9 +102,10 @@ def provisionClusterRoleBindings():
     if not createdServiceAccount:
       for template in gloo_templates:
         if template.find(serviceaccounts_filename_map[serviceaccount]) >= 0:
-          local('{templateCmd} -s {template} -f {overridesFile} {chartDir}/gloo -g | kubectl --namespace=default apply --validate=0 --force -f -'.format(
+          local('{templateCmd} -s {template} -f {baseConfig} -f {overridesFile} {chartDir}/gloo -g | kubectl --namespace=default apply --validate=0 --force -f -'.format(
             chartDir=absolute_gloo_chart_dir,
             templateCmd=gloo_helm_template_cmd,
+            baseConfig=tidepool_helm_values_file,
             overridesFile=tidepool_helm_overrides_file,
             template=template.replace('{}/gloo/'.format(absolute_gloo_chart_dir), ""),
           ))
@@ -135,9 +139,10 @@ def provisionConfigMaps():
   for configmap in required_configmaps:
     for template in gloo_templates:
       if template.find(configmaps_filename_map[configmap]) >= 0:
-        local('{templateCmd} -s {template} -f {overridesFile} {chartDir}/gloo -g | kubectl --namespace=default apply --validate=0 --force -f -'.format(
+        local('{templateCmd} -s {template} -f {baseConfig} -f {overridesFile} {chartDir}/gloo -g | kubectl --namespace=default apply --validate=0 --force -f -'.format(
           chartDir=absolute_gloo_chart_dir,
           templateCmd=gloo_helm_template_cmd,
+          baseConfig=tidepool_helm_values_file,
           overridesFile=tidepool_helm_overrides_file,
           template=template.replace('{}/gloo/'.format(absolute_gloo_chart_dir), ""),
         ))
@@ -149,9 +154,10 @@ def provisionGlooGateway():
     if template.find('service-account') >= 0 or template.find('gateway-proxy-configmap') >= 0:
       local('rm {}'.format(template))
 
-  k8s_yaml(local('{templateCmd} -f {overridesFile} {chartDir}/gloo'.format(
+  k8s_yaml(local('{templateCmd} -f {baseConfig} -f {overridesFile} {chartDir}/gloo'.format(
     chartDir=absolute_gloo_chart_dir,
     templateCmd=gloo_helm_template_cmd,
+    baseConfig=tidepool_helm_values_file,
     overridesFile=tidepool_helm_overrides_file,
   )))
 

--- a/Tiltfile.global
+++ b/Tiltfile.global
@@ -8,8 +8,11 @@ def getNested(dict, path, fallback=None):
     value = value.get(path_segment, {})
   return value or fallback
 
+def getHelmValuesFile():
+  return './Tiltconfig.yaml'
+
 def getHelmOverridesFile():
-  tidepool_helm_overrides_file = './Tiltconfig.yaml'
+  tidepool_helm_overrides_file = getHelmValuesFile()
   localOverrides = read_yaml('./local/Tiltconfig.yaml', False)
 
   if type(localOverrides) == 'dict':
@@ -18,7 +21,10 @@ def getHelmOverridesFile():
   return tidepool_helm_overrides_file
 
 def getConfig():
-  return read_yaml(getHelmOverridesFile())
+  config = read_yaml(getHelmValuesFile())
+  overrides = read_yaml(getHelmOverridesFile())
+  config.update(overrides)
+  return config
 
 def isShutdown():
   return bool(int(str(local('printf ${SHUTTING_DOWN-0}'))))


### PR DESCRIPTION
Pulling in remote updates should now be much more robust, and the overrides file should be much easier to maintain.

