### PR TITLE
fix public docker api port forward, add modern linux compatibility

### DIFF
--- a/docker-compose.k8s.yml
+++ b/docker-compose.k8s.yml
@@ -1,12 +1,12 @@
 version: '3'
 services:
   server:
-    image: bsycorp/kind:latest-1.18
+    image: tidepool/kind:latest-1.21
     privileged: true
     network_mode: bridge
     ports:
-      - 8443:8443
-      - 10080:10080
-      - 2375:2375
+      - 127.0.0.1:8443:8443
+      - 127.0.0.1:10080:10080
+      - 127.0.0.1:2375:2375
     volumes:
       - ${TIDEPOOL_DOCKER_MONGO_VOLUME}:/data/db


### PR DESCRIPTION
The current configuration needs a newer docker version to work on newer linux releases (fedora >32, etc), this change pulls a newer container with docker 20.10.6, which added support for cgroupsv2, also updates kubernetes and minikube.

ports exposed are now restricted to localhost to prevent any unintended docker api access.