### PR TITLE
[BACK-2379] Remove direct connect connection in MongoDB for latest drivers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ local/*
 .helm
 tilt_modules/
 .idea/
+.DS_Store

--- a/Tiltconfig.yaml
+++ b/Tiltconfig.yaml
@@ -91,7 +91,7 @@ mongo:
       Password: ""
       Database: "admin"
       Tls: "false"
-      OptParams: "connect=direct"
+      OptParams: "directConnection=true"
 ### MongoDB Config End ###
 
 ### Carelink API Config Start ###carelink:

--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.14.5
+version: 0.15.0
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org


### PR DESCRIPTION
Not a supported connection option in latest Node.js 5.x mongodb driver. Returns error if set.