### PR TITLE
[WEB-2395] Add GA Measurement ID env variable to local Tilt builds 

### DIFF
--- a/Tiltconfig.yaml
+++ b/Tiltconfig.yaml
@@ -231,6 +231,7 @@ blip:
   apiHost: 'http://localhost:31500'
   realmHost: 'http://localhost:32000'
   rollbarPostServerToken: '' # Rollbar post_server_item access token for posting source maps on production builds
+  reactAppGAID: '' # Google Analytics 4 ID
   webpackDevTool: cheap-module-eval-source-map
   webpackDevToolViz: cheap-source-map # Suggest changing `cheap-source-map` to the slower, but far more helpful `source-map` if debugging errors in viz package files
   webpackPublicPath: 'http://localhost:31500/'

--- a/Tiltconfig.yaml
+++ b/Tiltconfig.yaml
@@ -259,7 +259,6 @@ blip:
       - ALL
   # i18nEnabled: 'true'                                       # Uncomment to enable internationalization UI
   # rxEnabled: 'true'                                         # Uncomment to enable prescriptions UI
-  # clinicsEnabled: 'true'                                    # Uncomment to enable clinics UI
   pendoEnabled: 'false'                                       # Set to `true` to enable pendo
   # disableDevTools: true                                     # Uncomment if working with large data sets is sluggish in development build
   # buildTarget: production                                   # Uncomment to run minified production builds

--- a/Tiltfile
+++ b/Tiltfile
@@ -290,11 +290,10 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
                 packageName=packageName,
               )
 
-        buildCommand += ' --build-arg LINKED_PKGS={linkedPackages} --build-arg ROLLBAR_POST_SERVER_TOKEN={rollbarPostServerToken} --build-arg REACT_APP_GAID={reactAppGAID} --build-arg CLINICS_ENABLED={clinicsEnabled} --build-arg PENDO_ENABLED={pendoEnabled} --build-arg I18N_ENABLED={i18nEnabled} --build-arg RX_ENABLED={rxEnabled}'.format(
+        buildCommand += ' --build-arg LINKED_PKGS={linkedPackages} --build-arg ROLLBAR_POST_SERVER_TOKEN={rollbarPostServerToken} --build-arg REACT_APP_GAID={reactAppGAID} --build-arg PENDO_ENABLED={pendoEnabled} --build-arg I18N_ENABLED={i18nEnabled} --build-arg RX_ENABLED={rxEnabled}'.format(
           linkedPackages=','.join(activeLinkedPackages),
           rollbarPostServerToken=overrides.get('rollbarPostServerToken'),
           reactAppGAID=overrides.get('reactAppGAID'),
-          clinicsEnabled=overrides.get('clinicsEnabled'),
           pendoEnabled=overrides.get('pendoEnabled'),
           i18nEnabled=overrides.get('i18nEnabled'),
           rxEnabled=overrides.get('rxEnabled'),

--- a/Tiltfile
+++ b/Tiltfile
@@ -290,9 +290,10 @@ def applyServiceOverrides(tidepool_helm_template_cmd):
                 packageName=packageName,
               )
 
-        buildCommand += ' --build-arg LINKED_PKGS={linkedPackages} --build-arg ROLLBAR_POST_SERVER_TOKEN={rollbarPostServerToken} --build-arg CLINICS_ENABLED={clinicsEnabled} --build-arg PENDO_ENABLED={pendoEnabled} --build-arg I18N_ENABLED={i18nEnabled} --build-arg RX_ENABLED={rxEnabled}'.format(
+        buildCommand += ' --build-arg LINKED_PKGS={linkedPackages} --build-arg ROLLBAR_POST_SERVER_TOKEN={rollbarPostServerToken} --build-arg REACT_APP_GAID={reactAppGAID} --build-arg CLINICS_ENABLED={clinicsEnabled} --build-arg PENDO_ENABLED={pendoEnabled} --build-arg I18N_ENABLED={i18nEnabled} --build-arg RX_ENABLED={rxEnabled}'.format(
           linkedPackages=','.join(activeLinkedPackages),
           rollbarPostServerToken=overrides.get('rollbarPostServerToken'),
+          reactAppGAID=overrides.get('reactAppGAID'),
           clinicsEnabled=overrides.get('clinicsEnabled'),
           pendoEnabled=overrides.get('pendoEnabled'),
           i18nEnabled=overrides.get('i18nEnabled'),


### PR DESCRIPTION
[WEB-2395]

Related PRs:
 - https://github.com/tidepool-org/blip/pull/1240
 - https://github.com/tidepool-org/tools/pull/97

[WEB-2395]: https://tidepool.atlassian.net/browse/WEB-2395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ