### PR TITLE
Clarify the Debian/Ubuntu netcat package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ yum install nc
 dnf install nc
 
 # Debian/Ubuntu
-sudo apt-get install Netcat
+sudo apt-get install netcat-openbsd # or netcat-traditional
 ```
 
 After installing Netcat, you can verify it's working by typing `nc -h` in your terminal.


### PR DESCRIPTION
There are two netcat packages available in modern Debian-based distros. Of the two, netcat-openbsd is a bit newer and supports IPv6 and Unix sockets, so is generally superior, though from what I could tell by grepping the codebase, either should work (the -z and -v flags are identical between the two).