### PR TITLE
adds env vars to configure external client for hydrophone

### DIFF
--- a/charts/tidepool/charts/hydrophone/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/hydrophone/templates/1-deployment.yaml
@@ -65,9 +65,15 @@ spec:
             secretKeyRef:
               name: server
               key: ServiceAuth
-
         - name: TIDEPOOL_AUTH_CLIENT_ADDRESS
           value: "http://shoreline:{{.Values.global.ports.shoreline}}"
+        - name: TIDEPOOL_AUTH_CLIENT_EXTERNAL_SERVER_SESSION_TOKEN_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: server
+              key: ServiceAuth
+        - name: TIDEPOOL_AUTH_CLIENT_EXTERNAL_ADDRESS
+          value: "http://internal.{{.Release.Namespace}}"
         - name: TIDEPOOL_DATA_CLIENT_ADDRESS
           value: "http://data:{{.Values.global.ports.data}}"
         - name: TIDEPOOL_SEAGULL_CLIENT_ADDRESS


### PR DESCRIPTION
Now that hydrophone uses the alerts client in platform, it needs these values to be able to instantiate the external client that will handle token/session authentication.

BACK-2500