### PR TITLE
bump export service's GET timeout from 3m => 6m

### DIFF
--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.15.20
+version: 0.15.22
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org

--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.15.19
+version: 0.15.20
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org

--- a/charts/tidepool/charts/export/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/export/templates/4-routetable.yaml
@@ -27,7 +27,7 @@ spec:
         upstream:
           name: export
     options:
-      timeout: '3m'
+      timeout: '6m'
       extauth:
        disable: true
 {{- end }}

--- a/charts/tidepool/charts/export/templates/7-serviceprofile.yaml
+++ b/charts/tidepool/charts/export/templates/7-serviceprofile.yaml
@@ -10,7 +10,7 @@ spec:
       method: GET
       pathRegex: /export/.*
     name: /export/_get_export
-    timeout: 3m
+    timeout: 6m
   - condition:
       method: POST
       pathRegex: /export/.*


### PR DESCRIPTION
We're seeing some timeouts when streaming results, so bumping the timeout.