### PR TITLE
[BACK-2572] Add no index creation and no user events handler chart for shadowed cluster.

### DIFF
--- a/charts/tidepool/charts/auth/templates/0-configmap.yaml
+++ b/charts/tidepool/charts/auth/templates/0-configmap.yaml
@@ -12,5 +12,6 @@ data:
   AppleDeviceCheckKeyId: {{ .AppleDeviceCheckKeyId | default "" }}
   AppleDeviceCheckKeyIssuer: {{ .AppleDeviceCheckKeyIssuer | default "" }}
   AppleDeviceCheckUseDevelopment: "{{ .AppleDeviceCheckUseDevelopment | default "true" }}"
+  UserEventsHandlerDisable: "{{ .UserEventsHandlerDisable | default "false" }}"
 {{- end }}
 {{- end }}

--- a/charts/tidepool/charts/auth/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/auth/templates/1-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       app: auth
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-  replicas: {{ .Values.deployment.replicas | default 1 }}
+  replicas: {{ .Values.deployment.replicas }}
   strategy: {}
   template:
     metadata:
@@ -86,6 +86,12 @@ spec:
             secretKeyRef:
               name: dexcom
               key: StateSalt
+              optional: true
+        - name: TIDEPOOL_AUTH_SERVICE_USER_EVENTS_HANDLER_DISABLE
+          valueFrom:
+            configMapKeyRef:
+              name: auth
+              key: UserEventsHandlerDisable
               optional: true
         - name: TIDEPOOL_AUTH_SERVICE_DOMAIN
           value: {{ .Values.global.gateway.default.domain }}

--- a/charts/tidepool/charts/auth/values.yaml
+++ b/charts/tidepool/charts/auth/values.yaml
@@ -12,6 +12,7 @@ configmap:
     AppleDeviceCheckKeyIssuer: "75U4X84TEG"
     AppleDeviceCheckKeyId: "B542R658GF"
     AppleDeviceCheckUseDevelopment: "true"
+    UserEventsHandlerDisable: "false"
 deployment:
   # -- auth Docker image
   image: tidepool/platform-auth:master-latest

--- a/charts/tidepool/charts/blob/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/blob/templates/1-deployment.yaml
@@ -49,6 +49,12 @@ spec:
         {{ include "charts.platform.env.clients" .}}
         {{ include "charts.kafka.common" .}}
         {{ include "charts.kafka.cloudevents.client" (dict "Values" .Values "Release" .Release "client" "blob") }}
+        - name: TIDEPOOL_BLOB_SERVICE_USER_EVENTS_HANDLER_DISABLE
+          valueFrom:
+            configMapKeyRef:
+              name: blob
+              key: UserEventsHandlerDisable
+              optional: true
         - name: TIDEPOOL_BLOB_SERVICE_SECRET
           valueFrom:
             secretKeyRef:

--- a/charts/tidepool/charts/data/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/data/templates/1-deployment.yaml
@@ -19,7 +19,6 @@ spec:
       app.kubernetes.io/name: {{ include "charts.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   replicas: {{ .Values.deployment.replicas }}
-  strategy: {}
   template:
     metadata:
       labels:

--- a/charts/tidepool/charts/data/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/data/templates/1-deployment.yaml
@@ -44,6 +44,12 @@ spec:
         {{ include "charts.platform.env.clients" .}}
         {{ include "charts.kafka.common" .}}
         {{ include "charts.kafka.cloudevents.client" (dict "Values" .Values "Release" .Release "client" "data") }}
+        - name: TIDEPOOL_DATA_SERVICE_USER_EVENTS_HANDLER_DISABLE
+          valueFrom:
+            configMapKeyRef:
+              name: data
+              key: UserEventsHandlerDisable
+              optional: true
         - name: TIDEPOOL_DATA_SERVICE_SECRET
           valueFrom:
             secretKeyRef:

--- a/charts/tidepool/charts/glooingress/templates/2-http-internal-virtual-service.yaml
+++ b/charts/tidepool/charts/glooingress/templates/2-http-internal-virtual-service.yaml
@@ -2,7 +2,15 @@
 {{- $internal := .Values.virtualServices.httpInternal }}
 {{- $spec := .Values.virtualServices.http }}
 {{- $port := $spec.port | default "80" }}
-{{ if or (not $spec.enabled) ($spec.redirect) }}
+# The reason for using a "disabled" field instead of the "enabled" field that
+# we conventionally use elsewhere is because by default an internal
+# VirtualService is created if the http VirtualService is not enabled or it has
+# an https redirect. This means there's no way to NOT have any VirtualService.
+# This way, we can disable all VirtualServices for a Release. The field name is
+# "disabled" just in case some service actually depends on the original logic
+# of an internal VirtualService being created. This is used for shadowed clusters
+# where no VirtualServices are needed.
+{{ if and (or (not $spec.enabled) ($spec.redirect)) (not $internal.disabled) }}
 ---
 apiVersion: gateway.solo.io/v1
 kind: VirtualService

--- a/charts/tidepool/charts/jellyfish/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/jellyfish/templates/1-deployment.yaml
@@ -73,11 +73,11 @@ spec:
               name: server
               key: ServiceAuth
         - name: TIDEPOOL_AUTH_CLIENT_ADDRESS
-          value: "shoreline:{{.Values.global.ports.shoreline}}"
+          value: "{{ .Values.global.hostnames.shoreline }}:{{ .Values.global.ports.shoreline }}"
         - name: TIDEPOOL_SEAGULL_CLIENT_ADDRESS
-          value: "seagull:{{.Values.global.ports.seagull}}"
+          value: "{{ .Values.global.hostnames.seagull }}:{{ .Values.global.ports.seagull }}"
         - name: TIDEPOOL_PERMISSION_CLIENT_ADDRESS
-          value: "gatekeeper:{{.Values.global.ports.gatekeeper}}"
+          value: "{{ .Values.global.hostnames.gatekeeper }}:{{ .Values.global.ports.gatekeeper }}"
         image: "{{ .Values.deployment.image }}"
         securityContext:
           {{- .Values.podSecurityContext | toYaml | nindent 10 }}

--- a/charts/tidepool/charts/tidewhisperer/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/tidewhisperer/templates/1-deployment.yaml
@@ -69,18 +69,18 @@ spec:
           value: |
             {
                 "auth": {
-                  "address": "http://auth:{{.Values.global.ports.auth}}",
+                  "address": "http://{{.Values.global.hostnames.shoreline}}:{{.Values.global.ports.shoreline}}",
                   "userAgent": "Tidepool-TideWhisperer"
                 },
-                "gatekeeper": {"serviceSpec": {"type": "static", "hosts": ["http://gatekeeper:{{.Values.global.ports.gatekeeper}}"]}},
+                "gatekeeper": {"serviceSpec": {"type": "static", "hosts": ["http://{{.Values.global.hostnames.gatekeeper}}:{{.Values.global.ports.gatekeeper}}"]}},
                 "hakken": {
                   "host": "hakken",
                   "skipHakken": true
                   },
-                "seagull": {"serviceSpec": {"type": "static", "hosts": ["http://seagull:{{.Values.global.ports.seagull}}"]}},
+                "seagull": {"serviceSpec": {"type": "static", "hosts": ["http://{{ .Values.global.hostnames.seagull }}:{{ .Values.global.ports.seagull }}"]}},
                 "shoreline": {
                     "name": "tide-whisperer",
-                    "serviceSpec": {"type": "static", "hosts": ["http://shoreline:{{.Values.global.ports.shoreline}}"]},
+                    "serviceSpec": {"type": "static", "hosts": ["http://{{ .Values.global.hostnames.shoreline }}:{{ .Values.global.ports.shoreline }}"]},
                     "tokenRefreshInterval": "1h"
                 }
             }

--- a/charts/tidepool/templates/_helpers.tpl
+++ b/charts/tidepool/templates/_helpers.tpl
@@ -57,22 +57,24 @@ Create environment variables used by all platform services.
 
 {{ define "charts.platform.env.clients" }}
         - name: TIDEPOOL_AUTH_CLIENT_ADDRESS
-          value: http://{{.Values.global.hostnames.auth}}:{{.Values.global.ports.auth}}
+          value: "http://{{ .Values.global.hostnames.auth }}:{{ .Values.global.ports.auth }}"
         - name: TIDEPOOL_AUTH_CLIENT_EXTERNAL_ADDRESS
-          value: "http://{{ include "hostname.internal" .}}"
+          value: "http://{{ .Values.global.hostnames.shoreline }}:{{ .Values.global.ports.shoreline }}"
         - name: TIDEPOOL_AUTH_CLIENT_EXTERNAL_SERVER_SESSION_TOKEN_SECRET
           valueFrom:
             secretKeyRef:
               name: server
               key: ServiceAuth
+        - name: TIDEPOOL_AUTH_CLIENT_EXTERNAL_PATH_PREFIX
+          value: {{ .Values.global.platformExternalAuthPathPrefix | quote }}
         - name: TIDEPOOL_BLOB_CLIENT_ADDRESS
-          value: http://{{.Values.global.hostnames.blob}}:{{.Values.global.ports.blob}}
+          value: "http://{{ .Values.global.hostnames.blob }}:{{ .Values.global.ports.blob }}"
         - name: TIDEPOOL_DATA_CLIENT_ADDRESS
-          value: http://{{.Values.global.hostnames.data}}:{{.Values.global.ports.data}}
+          value: "http://{{ .Values.global.hostnames.data }}:{{ .Values.global.ports.data }}"
         - name: TIDEPOOL_DATA_SOURCE_CLIENT_ADDRESS
-          value: http://{{.Values.global.hostnames.data}}:{{.Values.global.ports.data}}
+          value: "http://{{ .Values.global.hostnames.data }}:{{ .Values.global.ports.data }}"
         - name: TIDEPOOL_DEVICES_CLIENT_ADDRESS
-          value: {{.Values.global.hostnames.devices}}:{{.Values.global.ports.devices_grpc}}
+          value: "http://{{ .Values.global.hostnames.devices }}:{{ .Values.global.ports.devices_grpc }}"
         - name: TIDEPOOL_DEXCOM_CLIENT_ADDRESS
           valueFrom:
             configMapKeyRef:
@@ -86,11 +88,11 @@ Create environment variables used by all platform services.
         - name: TIDEPOOL_METRIC_CLIENT_ADDRESS
           value: "http://{{ include "hostname.internal" .}}"
         - name: TIDEPOOL_PERMISSION_CLIENT_ADDRESS
-          value: http://{{.Values.global.hostnames.gatekeeper}}:{{.Values.global.ports.gatekeeper}}
+          value: "http://{{ .Values.global.hostnames.gatekeeper }}:{{ .Values.global.ports.gatekeeper }}"
         - name: TIDEPOOL_CONFIRMATION_CLIENT_ADDRESS
-          value: "http://{{.Values.global.hostnames.hydrophone}}:{{.Values.global.ports.hydrophone}}"
+          value: "http://{{ .Values.global.hostnames.hydrophone }}:{{ .Values.global.ports.hydrophone }}"
         - name: TIDEPOOL_TASK_CLIENT_ADDRESS
-          value: http://{{.Values.global.hostnames.task}}:{{.Values.global.ports.task}}
+          value: "http://{{ .Values.global.hostnames.task }}:{{ .Values.global.ports.task }}"
         - name: TIDEPOOL_USER_CLIENT_ADDRESS
           value: "http://{{ include "hostname.internal" .}}"
         - name: TIDEPOOL_CLINIC_CLIENT_ADDRESS

--- a/charts/tidepool/templates/_helpers.tpl
+++ b/charts/tidepool/templates/_helpers.tpl
@@ -51,24 +51,28 @@ Create environment variables used by all platform services.
 */}}
 }
 
+{{- define "hostname.internal" -}}
+{{- .Values.global.hostnames.internal | default (printf "internal-%s" .Release.Namespace) -}}
+{{- end -}}
+
 {{ define "charts.platform.env.clients" }}
         - name: TIDEPOOL_AUTH_CLIENT_ADDRESS
-          value: http://auth:{{.Values.global.ports.auth}}
+          value: http://{{.Values.global.hostnames.auth}}:{{.Values.global.ports.auth}}
         - name: TIDEPOOL_AUTH_CLIENT_EXTERNAL_ADDRESS
-          value: "http://internal.{{.Release.Namespace}}"
+          value: "http://{{ include "hostname.internal" .}}"
         - name: TIDEPOOL_AUTH_CLIENT_EXTERNAL_SERVER_SESSION_TOKEN_SECRET
           valueFrom:
             secretKeyRef:
               name: server
               key: ServiceAuth
         - name: TIDEPOOL_BLOB_CLIENT_ADDRESS
-          value: http://blob:{{.Values.global.ports.blob}}
+          value: http://{{.Values.global.hostnames.blob}}:{{.Values.global.ports.blob}}
         - name: TIDEPOOL_DATA_CLIENT_ADDRESS
-          value: http://data:{{.Values.global.ports.data}}
+          value: http://{{.Values.global.hostnames.data}}:{{.Values.global.ports.data}}
         - name: TIDEPOOL_DATA_SOURCE_CLIENT_ADDRESS
-          value: http://data:{{.Values.global.ports.data}}
+          value: http://{{.Values.global.hostnames.data}}:{{.Values.global.ports.data}}
         - name: TIDEPOOL_DEVICES_CLIENT_ADDRESS
-          value: devices:{{.Values.global.ports.devices_grpc}}
+          value: {{.Values.global.hostnames.devices}}:{{.Values.global.ports.devices_grpc}}
         - name: TIDEPOOL_DEXCOM_CLIENT_ADDRESS
           valueFrom:
             configMapKeyRef:
@@ -80,17 +84,17 @@ Create environment variables used by all platform services.
               name: dexcom
               key: AuthorizeURL
         - name: TIDEPOOL_METRIC_CLIENT_ADDRESS
-          value: "http://internal.{{.Release.Namespace}}"
+          value: "http://{{ include "hostname.internal" .}}"
         - name: TIDEPOOL_PERMISSION_CLIENT_ADDRESS
-          value: http://gatekeeper:{{.Values.global.ports.gatekeeper}}
+          value: http://{{.Values.global.hostnames.gatekeeper}}:{{.Values.global.ports.gatekeeper}}
         - name: TIDEPOOL_CONFIRMATION_CLIENT_ADDRESS
-          value: "http://hydrophone:{{.Values.global.ports.hydrophone}}"
+          value: "http://{{.Values.global.hostnames.hydrophone}}:{{.Values.global.ports.hydrophone}}"
         - name: TIDEPOOL_TASK_CLIENT_ADDRESS
-          value: http://task:{{.Values.global.ports.task}}
+          value: http://{{.Values.global.hostnames.task}}:{{.Values.global.ports.task}}
         - name: TIDEPOOL_USER_CLIENT_ADDRESS
-          value: "http://internal.{{.Release.Namespace}}"
+          value: "http://{{ include "hostname.internal" .}}"
         - name: TIDEPOOL_CLINIC_CLIENT_ADDRESS
-          value: "http://internal.{{.Release.Namespace}}"
+          value: "http://{{ include "hostname.internal" .}}"
 {{ end }}
 
 {{ define "charts.tracing.common" }}
@@ -167,6 +171,12 @@ Create environment variables used by all platform services.
 {{ include "charts.mongo.params" . }}
         - name: TIDEPOOL_STORE_DATABASE
           value: tidepool
+        - name: TIDEPOOL_DISABLE_INDEX_CREATION
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.mongo.secretName }}
+              key: DisabledIndexCreation
+              optional: true
 {{ end }}
 
 {{- define "charts.routing.opts.shadowing" -}}
@@ -200,7 +210,7 @@ Create liveness and readiness probes for platform services.
 {{- define "charts.init.shoreline" -}}
       - name: init-shoreline
         image: busybox:1.31.1
-        command: ['sh', '-c', 'until nc -zvv shoreline {{.Values.global.ports.shoreline}}; do echo waiting for shoreline; sleep 2; done;']
+        command: ['sh', '-c', 'until nc -zvv {{.Values.global.hostnames.shoreline}} {{.Values.global.ports.shoreline}}; do echo waiting for shoreline; sleep 2; done;']
 {{- end -}}
 
 {{- define "charts.labels.standard" }}

--- a/charts/tidepool/values.yaml
+++ b/charts/tidepool/values.yaml
@@ -56,6 +56,32 @@ global:
   linkerdsupport:
     # -- whether to include linkerdsupport subchart with Linkerd service profiles
     enabled: true
+  # -- service hostnames
+  hostnames:
+    # -- auth service hostname
+    auth: "auth"
+    # -- blob service hostname
+    blob: "blob"
+    # -- clinic service hostname
+    clinic: "clinic"
+    # -- data service hostname
+    data: "data"
+    # -- devices service hostname
+    devices: "devices"
+    # -- gatekeeper service hostname
+    gatekeeper: "gatekeeper"
+    # -- hydrophone service hostname
+    hydrophone: "hydrophone"
+    # -- internal virtual service hostname
+    internal: "internal"
+    # -- metric service hostname
+    metric: "highwater"
+    # -- shoreline service hostname
+    shoreline: "shoreline"
+    # -- task service hostname
+    task: "task"
+    # -- user service hostname
+    user: "user"
   ports:
     # -- blip service internal port
     blip: 31500

--- a/charts/tidepool/values.yaml
+++ b/charts/tidepool/values.yaml
@@ -56,6 +56,8 @@ global:
   linkerdsupport:
     # -- whether to include linkerdsupport subchart with Linkerd service profiles
     enabled: true
+  # -- for a shadowed cluster only, what URL path prefix should platform services add (if any) when calling out to shoreline
+  platformExternalAuthPathPrefix: ''
   # -- service hostnames
   hostnames:
     # -- auth service hostname
@@ -76,6 +78,8 @@ global:
     internal: "internal"
     # -- metric service hostname
     metric: "highwater"
+    # -- seagull service hostname
+    seagull: "seagull"
     # -- shoreline service hostname
     shoreline: "shoreline"
     # -- task service hostname


### PR DESCRIPTION
Update of the shadowed cluster as the previous was too out of date with master. Add option to not include any VirtualServices as they are not needed in the shadowed cluster.