### PR TITLE
set TIDEPOOL_LOGGER_PACKAGE env var via helm chart

### DIFF
--- a/charts/tidepool/templates/_helpers.tpl
+++ b/charts/tidepool/templates/_helpers.tpl
@@ -120,6 +120,8 @@ Create environment variables used by all platform services.
           value: local
         - name: TIDEPOOL_LOGGER_LEVEL
           value: {{ .Values.global.logLevel }}
+        - name: TIDEPOOL_LOGGER_PACKAGE
+          value: {{ .Values.global.loggerPackage | default "json" }}
         - name: TIDEPOOL_SERVER_TLS
           value: "false"
         - name: TIDEPOOL_AUTH_SERVICE_SECRET


### PR DESCRIPTION
Setting this value would allow services to use alternate logging packages, for example when running/testing locally, it's sometimes useful to log in a format other than JSON.

See https://github.com/tidepool-org/platform/pull/714 for one such example logger.

One can choose to configure this like so:

    # local/Tiltconfig.yaml
    global:
      loggerPackage: devlog

And that value would get picked up and passed as TIDEPOOL_LOGGER_PACKAGE to services started via the helm chart.

It can also be overridden on a short-term basis via:

    $ kubectl set env <deployment> TIDEPOOL_LOGGER_PACKAGE=devlog

Followed by restarting the deployment.