### PR TITLE
allow a port to be specified for tilt

### DIFF
--- a/bin/tidepool
+++ b/bin/tidepool
@@ -89,7 +89,7 @@ server_stop() {
 }
 
 start() {
-  cd ${DIR} && set_tilt_env ${1-} && tilt up -dv --port=0 --legacy
+  cd ${DIR} && set_tilt_env ${1-} && tilt up -dv --port=${TIDEPOOL_TILT_PORT:-0} --legacy
 }
 
 stop() {


### PR DESCRIPTION
This should be 100% opt-in. Setting the TIDEPOOL_TILT_PORT env var causes the port specified to be used for the main Tilt instance (the Kafka Tilt instance is unaffected, and will still use a random port).

Specifying this port has two effects for me:

1. It lets the <enter> key in the Tilt CLI open the web UI in my browser.
2. Being a static port, I can bookmark it.