### PR TITLE
Remove null options in data routetable route.

### DIFF
--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.16.5
+version: 0.16.6
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org

--- a/charts/tidepool/charts/data/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/data/templates/4-routetable.yaml
@@ -185,8 +185,8 @@ spec:
       single:
         upstream:
           name: data
-    options:
 {{- if .Values.shadowing.enabled }}
+    options:
       {{- include "charts.routing.opts.shadowing" . | nindent 6 }}
 {{- end }}
   - matchers:


### PR DESCRIPTION
In the data routetable, one of the routes, depending on the gloo version, it will either be an empty object or null if shadowing is not enabled, leading to an error during deploy.