### PR TITLE
Add appName to mongodb connection string opt params

### DIFF
--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.17.0
+version: 0.17.1
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org

--- a/charts/tidepool/templates/_helpers.tpl
+++ b/charts/tidepool/templates/_helpers.tpl
@@ -153,13 +153,13 @@ Create environment variables used by all platform services.
             secretKeyRef:
               name: {{ .Values.mongo.secretName }}
               key: Addresses
-        - name: TIDEPOOL_STORE_OPT_PARAMS
+        - name: TIDEPOOL_STORE_OPT_PARAMS_BASE
           valueFrom:
             secretKeyRef:
               name: {{ .Values.mongo.secretName }}
               key: OptParams
-        - name: TIDEPOOL_STORE_APP_NAME
-          value: {{ .Chart.Name | quote }}
+        - name: TIDEPOOL_STORE_OPT_PARAMS
+          value: "$(TIDEPOOL_STORE_OPT_PARAMS_BASE)&appName={{ .Chart.Name | urlquery }}"
         - name: TIDEPOOL_STORE_TLS
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Combine appName into mongodb connection string opts to better differentiate
b/t services w/o having to modify code of existing services.