### PR TITLE
use a feature flag for care partner alerts mongo connectors

### DIFF
--- a/charts/tidepool/charts/data/templates/8-care-partner-alerts-kafka-connector.yaml
+++ b/charts/tidepool/charts/data/templates/8-care-partner-alerts-kafka-connector.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.global.kafka.connect.enabled }}
+{{ if .Values.kafka.connectors.carePartnerAlerts.enabled }}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnector
 metadata:
@@ -23,4 +24,5 @@ spec:
     heartbeat.interval.ms: {{ .Values.global.kafka.connect.mongoHeartbeatIntervalMs }}
     heartbeat.topic.name: {{ .Release.Namespace }}-{{ .Values.global.kafka.connect.clusterName }}-heartbeat
   tasksMax: {{ .Values.global.kafka.connect.sourceTasksMax | int }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/data/templates/8-device-data-kafka-connector.yaml
+++ b/charts/tidepool/charts/data/templates/8-device-data-kafka-connector.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.global.kafka.connect.enabled }}
+{{ if .Values.kafka.connectors.carePartnerAlerts.enabled }}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnector
 metadata:
@@ -33,4 +34,5 @@ spec:
     heartbeat.interval.ms: {{ .Values.global.kafka.connect.mongoHeartbeatIntervalMs }}
     heartbeat.topic.name: {{ .Release.Namespace }}-{{ .Values.global.kafka.connect.clusterName }}-heartbeat
   tasksMax: {{ .Values.global.kafka.connect.sourceTasksMax | int }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/data/values.yaml
+++ b/charts/tidepool/charts/data/values.yaml
@@ -34,6 +34,9 @@ kafka:
   configmapName: kafka
   # -- name of the configmap containing the kafka broker and credentials to use
   secretName: kafka
+  connectors:
+    carePartnerAlerts:
+      enabled: false
 # -- node selector configuration
 nodeSelector: {}
 # -- tolerations


### PR DESCRIPTION
As they're not in use right now, they tend to fall off of the op log
and cause needless alerts.

BACK-3365