### PR TITLE
add alerts retry delays configuration

### DIFF
--- a/charts/tidepool/charts/data/templates/0-configmap.yaml
+++ b/charts/tidepool/charts/data/templates/0-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
 {{ include "charts.labels.standard" . }}
 {{ with .Values.configmap.data_ }}
 data:
+  AlertsRetryDelays: {{ .AlertsRetryDelays | default "1s" }}
   PusherAPNSKeyID: {{ .PusherAPNSKeyID | default "" }}
   PusherAPNSTeamID: {{ .PusherAPNSTeamID | default "" }}
   PusherAPNSBundleID: {{ .PusherAPNSBundleID | default "" }}

--- a/charts/tidepool/charts/data/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/data/templates/1-deployment.yaml
@@ -119,6 +119,12 @@ spec:
         - name: {{ $key }}
           value: {{ $val | quote }}
 {{- end }}
+        - name: TIDEPOOL_DATA_SERVICE_ALERTS_RETRY_DELAYS
+          valueFrom:
+            configMapKeyRef:
+              name: data
+              key: AlertsRetryDelays
+              optional: true
         - name: TIDEPOOL_DATA_SERVICE_PUSHER_APNS_SIGNING_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/tidepool/charts/data/values.yaml
+++ b/charts/tidepool/charts/data/values.yaml
@@ -15,6 +15,7 @@ deployment:
 configmap:
   enabled: true
   data_:
+    AlertsRetryDelays: "1s" # comma-separated values for time.ParseDuration
     PusherAPNSKeyID: "QA3495JW4S"
     PusherAPNSTeamID: "75U4X84TEG"
     PusherAPNSBundleID: "org.tidepool.carepartner"


### PR DESCRIPTION
So that the retry steps for Care Partner Alerts can be specified via
configuration.

The values must be parseable by time.ParseDuration.

BACK-2559
