### PR TITLE
[BACK-3756] Add JWKS configuration to Abbott chart

### DIFF
--- a/charts/tidepool/charts/abbott/README.md
+++ b/charts/tidepool/charts/abbott/README.md
@@ -14,6 +14,7 @@ A Helm chart for Kubernetes
 | configmap.redirectURL | string | `""` | OAuth2 redirect URL |
 | configmap.tokenURL | string | `""` | OAuth2 token URL |
 | configmap.authorizeURL | string | `""` | OAuth2 authorization URL |
+| configmap.jwksURL | string | `""` | JWKS URL |
 | configmap.clientURL | string | `""` | client URL |
 | configmap.scopes | string | `""` | OAuth2 scopes |
 | configmap.partnerURL | string | `""` | partner URL |

--- a/charts/tidepool/charts/abbott/templates/0-configmap.yaml
+++ b/charts/tidepool/charts/abbott/templates/0-configmap.yaml
@@ -14,6 +14,7 @@ data:
 {{ end }}
   TokenURL: {{ .Values.configmap.tokenURL | default "" }}
   AuthorizeURL: {{ .Values.configmap.authorizeURL | default "" }}
+  JWKSURL: {{ .Values.configmap.jwksURL | default "" }}
   ClientURL: {{ .Values.configmap.clientURL | default "" }}
   Scopes: {{ .Values.configmap.scopes | default "" }}
   PartnerURL: {{ .Values.configmap.partnerURL | default "" }}

--- a/charts/tidepool/charts/abbott/values.yaml
+++ b/charts/tidepool/charts/abbott/values.yaml
@@ -3,6 +3,7 @@ configmap:
   redirectURL: ""
   tokenURL: ""
   authorizeURL: ""
+  jwksURL: ""
   clientURL: ""
   scopes: ""
   partnerURL: ""

--- a/charts/tidepool/charts/auth/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/auth/templates/1-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   name: auth
   namespace: {{.Release.Namespace}}
   annotations:
-    secret.reloader.stakater.com/reload: "server,{{ .Values.mongo.secretName }},abbott,dexcom,auth,twiist"
+    secret.reloader.stakater.com/reload: "server,{{ .Values.mongo.secretName }},abbott,dexcom,twiist,auth"
     configmap.reloader.stakater.com/reload: "abbott,dexcom,twiist"
 {{ if .Values.deployment.annotations }}
     {{- .Values.deployment.annotations | toYaml | nindent 4 }}
@@ -73,6 +73,12 @@ spec:
             configMapKeyRef:
               name: abbott
               key: TokenURL
+              optional: true
+        - name: TIDEPOOL_SERVICE_PROVIDER_ABBOTT_JWKS_URL
+          valueFrom:
+            configMapKeyRef:
+              name: abbott
+              key: JWKSURL
               optional: true
         - name: TIDEPOOL_SERVICE_PROVIDER_ABBOTT_CLIENT_ID
           valueFrom:

--- a/charts/tidepool/charts/auth/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/auth/templates/4-routetable.yaml
@@ -141,4 +141,8 @@ spec:
       single:
         upstream:
           name: auth
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/blob/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/blob/templates/4-routetable.yaml
@@ -53,4 +53,8 @@ spec:
       single:
         upstream:
           name: blob
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/clinic/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/clinic/templates/4-routetable.yaml
@@ -8,6 +8,7 @@ metadata:
   name: clinics
   namespace: {{ .Release.Namespace }}
 spec:
+  weight: 30
   routes:
     - matchers:
         - methods:
@@ -76,5 +77,8 @@ spec:
           upstream:
             name: clinic
             namespace: {{ .Release.Namespace }}
-  weight: 30
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/data/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/data/templates/1-deployment.yaml
@@ -75,6 +75,12 @@ spec:
               name: abbott
               key: TokenURL
               optional: true
+        - name: TIDEPOOL_SERVICE_PROVIDER_ABBOTT_JWKS_URL
+          valueFrom:
+            configMapKeyRef:
+              name: abbott
+              key: JWKSURL
+              optional: true
         - name: TIDEPOOL_SERVICE_PROVIDER_ABBOTT_CLIENT_ID
           valueFrom:
             secretKeyRef:

--- a/charts/tidepool/charts/data/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/data/templates/4-routetable.yaml
@@ -8,6 +8,7 @@ metadata:
     namespace: "{{ .Release.Namespace }}"
     app: tidepool
 spec:
+  weight: 10
   routes:
   - matchers:
     - methods:
@@ -429,5 +430,8 @@ spec:
       single:
         upstream:
           name: data
-  weight: 10
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/devices/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/devices/templates/4-routetable.yaml
@@ -17,4 +17,8 @@ spec:
       single:
         upstream:
           name: devices
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/export/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/export/templates/4-routetable.yaml
@@ -30,4 +30,8 @@ spec:
       timeout: '6m'
       extauth:
        disable: true
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/gatekeeper/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/gatekeeper/templates/4-routetable.yaml
@@ -47,4 +47,8 @@ spec:
           name: gatekeeper
     options:
       timeout: '30s'
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/highwater/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/highwater/templates/4-routetable.yaml
@@ -31,4 +31,8 @@ spec:
         retryOn: '5xx'
         numRetries: 3
         perTryTimeout: '15s'
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/hydrophone/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/hydrophone/templates/4-routetable.yaml
@@ -226,4 +226,8 @@ spec:
       timeout: '1m'
       extauth:
         disable: true
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/jellyfish/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/jellyfish/templates/4-routetable.yaml
@@ -33,4 +33,8 @@ spec:
       single:
         upstream:
           name: jellyfish
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/messageapi/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/messageapi/templates/4-routetable.yaml
@@ -24,4 +24,8 @@ spec:
           name: messageapi
     options:
       timeout: '30s'
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/prescription/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/prescription/templates/4-routetable.yaml
@@ -73,4 +73,8 @@ spec:
       single:
         upstream:
           name: prescription
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/seagull/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/seagull/templates/4-routetable.yaml
@@ -31,4 +31,8 @@ spec:
         retryOn: '5xx'
         numRetries: 3
         perTryTimeout: '15s'
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/task/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/task/templates/4-routetable.yaml
@@ -28,4 +28,8 @@ spec:
       single:
         upstream:
           name: task
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/tidewhisperer/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/tidewhisperer/templates/4-routetable.yaml
@@ -40,4 +40,8 @@ spec:
 {{- if .Values.shadowing.enabled }}
       {{- include "charts.routing.opts.shadowing" . | nindent 6 }}
 {{- end }}
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/tidepool/charts/uploader/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/uploader/templates/4-routetable.yaml
@@ -19,4 +19,8 @@ spec:
     options:
       extauth:
         disable: true
+{{- $extraRoutes := (.Values.deployment).extraRoutes | default ((.Values.global).deployment).extraRoutes | default list -}}
+{{- if $extraRoutes }}
+{{- toYaml $extraRoutes | nindent 2 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
- Add JWKS configuration to abbott chart
- Expose Abbott JWKS for both auth and data services
- Add extra routes for local development using telepresence
- https://tidepool.atlassian.net/browse/BACK-3756