### PR TITLE
[BACK-3925] Allow twiist data ingestion to list related provider sessions

### DIFF
--- a/charts/tidepool/charts/auth/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/auth/templates/4-routetable.yaml
@@ -63,7 +63,7 @@ spec:
       - GET
       - PUT
       - DELETE
-      regex: /v1/provider_sessions(/[^/]+)?
+      prefix: /v1/provider_sessions
     routeAction:
       single:
         upstream:

--- a/charts/tidepool/charts/auth/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/auth/templates/4-routetable.yaml
@@ -63,7 +63,7 @@ spec:
       - GET
       - PUT
       - DELETE
-      regex: /v1/provider_sessions/[^/]+
+      regex: /v1/provider_sessions(/[^/]+)?
     routeAction:
       single:
         upstream:


### PR DESCRIPTION
- Allow twiist data ingestion to list related provider sessions
- Add auth route to list provider sessions without user id
- https://tidepool.atlassian.net/browse/BACK-3925