### PR TITLE
increase clinic merge API endpoint timeout

### DIFF
--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.23.0
+version: 0.24.0
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org

--- a/charts/tidepool/charts/clinic/templates/7-serviceprofile.yaml
+++ b/charts/tidepool/charts/clinic/templates/7-serviceprofile.yaml
@@ -288,6 +288,11 @@ spec:
           isFailure: true
     - condition:
         method: POST
+        pathRegex: /v1/clinics/[^/]*/merge
+      name: POST /v1/clinics/{clinicId}/merge
+      timeout: 1m
+    - condition:
+        method: POST
         pathRegex: /v1/clinics/[^/]*/migrate
       name: POST /v1/clinics/{clinicId}/migrate
       responseClasses:


### PR DESCRIPTION
Bumping it up to 1 minute. This is an internal-only endpoint, so
making people wait up to a minute should be fine.

BACK-4216