### PR TITLE
increase clinic merge API endpoint timeout (part 2)

### DIFF
--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.24.0
+version: 0.24.1
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org

--- a/charts/tidepool/charts/clinic/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/clinic/templates/4-routetable.yaml
@@ -11,6 +11,17 @@ spec:
   routes:
     - matchers:
         - methods:
+            - POST
+          regex: /v1/clinics/[^/]+/merge
+      routeAction:
+        single:
+          upstream:
+            name: clinic
+            namespace: {{ .Release.Namespace }}
+      options:
+        timeout: 1m
+    - matchers:
+        - methods:
             - GET
             - DELETE
             - PATCH

--- a/charts/tidepool/charts/clinic/templates/7-serviceprofile.yaml
+++ b/charts/tidepool/charts/clinic/templates/7-serviceprofile.yaml
@@ -291,6 +291,21 @@ spec:
         pathRegex: /v1/clinics/[^/]*/merge
       name: POST /v1/clinics/{clinicId}/merge
       timeout: 1m
+      responseClasses:
+        - condition:
+            status:
+              min: 200
+              max: 399
+        - condition:
+            status:
+              min: 400
+              max: 599
+          isFailure: true
+    - condition:
+        method: POST
+        pathRegex: /v1/clinics/[^/]*/merge
+      name: POST /v1/clinics/{clinicId}/merge
+      timeout: 1m
     - condition:
         method: POST
         pathRegex: /v1/clinics/[^/]*/migrate

--- a/charts/tidepool/charts/glooingress/templates/2-http-internal-virtual-service.yaml
+++ b/charts/tidepool/charts/glooingress/templates/2-http-internal-virtual-service.yaml
@@ -44,5 +44,11 @@ spec:
             namespace: {{ .Release.Namespace }}
             app: tidepool
 
+    - matchers:
+      - regex: '/v1/clinics/[^/]*/merge'
+        methods:
+          - POST
+      options:
+        timeout: '60s'
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The changes from 5698df6 weren't effective. There are multiple places where timeouts can be configured. Hopefully this will catch them all.

This is an internal-only endpoint, so making people wait up to a minute should be fine.

BACK-4216