### PR TITLE
increase clinic merge API endpoint timeout (part 3)

### DIFF
--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.24.1
+version: 0.24.2
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org

--- a/charts/tidepool/charts/clinic/templates/4-routetable.yaml
+++ b/charts/tidepool/charts/clinic/templates/4-routetable.yaml
@@ -19,7 +19,7 @@ spec:
             name: clinic
             namespace: {{ .Release.Namespace }}
       options:
-        timeout: 1m
+        timeout: 15m
     - matchers:
         - methods:
             - GET

--- a/charts/tidepool/charts/clinic/templates/7-serviceprofile.yaml
+++ b/charts/tidepool/charts/clinic/templates/7-serviceprofile.yaml
@@ -290,7 +290,7 @@ spec:
         method: POST
         pathRegex: /v1/clinics/[^/]*/merge
       name: POST /v1/clinics/{clinicId}/merge
-      timeout: 1m
+      timeout: 15m
       responseClasses:
         - condition:
             status:
@@ -301,11 +301,6 @@ spec:
               min: 400
               max: 599
           isFailure: true
-    - condition:
-        method: POST
-        pathRegex: /v1/clinics/[^/]*/merge
-      name: POST /v1/clinics/{clinicId}/merge
-      timeout: 1m
     - condition:
         method: POST
         pathRegex: /v1/clinics/[^/]*/migrate

--- a/charts/tidepool/charts/glooingress/templates/2-http-internal-virtual-service.yaml
+++ b/charts/tidepool/charts/glooingress/templates/2-http-internal-virtual-service.yaml
@@ -43,12 +43,5 @@ spec:
           labels:
             namespace: {{ .Release.Namespace }}
             app: tidepool
-
-    - matchers:
-      - regex: '/v1/clinics/[^/]*/merge'
-        methods:
-          - POST
-      options:
-        timeout: '60s'
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The changes from e714b6c were effective, but not long enough.

This is an internal-only endpoint, so making people wait up to a minute should be fine.

BACK-4216
SIR-807