### PR TITLE
Expose Kafka Connect jvmOptions via chart values

### DIFF
--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.24.5
+version: 0.24.6
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org
@@ -11,5 +11,5 @@ home: https://github.com/tidepool-org/development/charts
 dependencies:
   - name: keycloak
     version: 0.4.7
-    repository: 'file://../keycloak'
+    repository: "file://../keycloak"
     condition: keycloak.enabled

--- a/charts/tidepool/charts/kafka/templates/1-kafka-connect-mongo-cluster.yaml
+++ b/charts/tidepool/charts/kafka/templates/1-kafka-connect-mongo-cluster.yaml
@@ -54,6 +54,10 @@ spec:
   replicas: {{ .Values.global.kafka.connect.replicas | int }}
   resources:
     {{- toYaml .Values.resources | nindent 10 }}
+{{- with .Values.jvmOptions }}
+  jvmOptions:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 {{ if .Values.global.kafka.connect.tlsEnabled }}
   tls:
     trustedCertificates: []

--- a/charts/tidepool/charts/kafka/values.yaml
+++ b/charts/tidepool/charts/kafka/values.yaml
@@ -58,6 +58,12 @@ resources:
     memory: "600Mi"
   limits:
     memory: "2Gi"
+# -- explicit JVM heap sizing; works around Strimzi's dynamic-heap script
+# misreading the cgroup limit on some kernels (it falls back to host memory
+# and asks for ~75% of the box, triggering a cgroup OOMKill).
+jvmOptions:
+  "-Xms": "768m"
+  "-Xmx": "1024m"
 secret:
   enabled: false
 podMonitor:

--- a/charts/tidepool/charts/kafka/values.yaml
+++ b/charts/tidepool/charts/kafka/values.yaml
@@ -58,12 +58,11 @@ resources:
     memory: "600Mi"
   limits:
     memory: "2Gi"
-# -- explicit JVM heap sizing; works around Strimzi's dynamic-heap script
-# misreading the cgroup limit on some kernels (it falls back to host memory
-# and asks for ~75% of the box, triggering a cgroup OOMKill).
-jvmOptions:
-  "-Xms": "768m"
-  "-Xmx": "1024m"
+# -- optional JVM heap sizing passed through to KafkaConnect.spec.jvmOptions.
+# Leave unset to use Strimzi's dynamic heap calculation (75% of the cgroup
+# memory limit). Override (e.g. via tiltronic-values-local.yaml) on hosts
+# where Strimzi's cgroup detection fails and the dynamic calc overshoots.
+jvmOptions: {}
 secret:
   enabled: false
 podMonitor:


### PR DESCRIPTION
## Summary

- Plumb `.Values.jvmOptions` through to `KafkaConnect.spec.jvmOptions`. Default is empty (`{}`), so existing deployments are
unaffected.

## Motivation

Strimzi sizes the Kafka Connect JVM heap as a percentage of the cgroup memory
limit (`STRIMZI_DYNAMIC_HEAP_PERCENTAGE`, default 75). That works well in
production but is environment-sensitive: on some host kernel + container-runtime
combinations the cgroup-v2 read fails and the script falls back to host
`/proc/meminfo`, requesting a heap size larger than the container can hold and
SIGKILLing the JVM (OOMKilled, exit 137) shortly after startup.

Exposing `jvmOptions` lets affected environments (currently observed in local
kind-based dev stacks on newer kernels) pin `-Xms`/`-Xmx` explicitly without a
chart fork. The accompanying tiltronic PR documents the workaround for local dev.

Related PR: https://github.com/tidepool-org/tiltronic/pull/42