### PR TITLE
[BACK-3938] Add patient_deletions source connector.

### DIFF
--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.25.1
+version: 0.25.2
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org

--- a/charts/tidepool/charts/clinic-worker/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/clinic-worker/templates/1-deployment.yaml
@@ -145,6 +145,11 @@ spec:
               optional: true
         - name: TIDEPOOL_EXPORT_CLIENT_ADDRESS
           value: "http://export:{{.Values.global.ports.export}}"
+        - name: TIDEPOOL_DATA_SERVICE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: data
+              key: ServiceAuth
         - name: EMAIL_REMINDERS_INTERVAL
           valueFrom:
             configMapKeyRef:

--- a/charts/tidepool/charts/clinic-worker/templates/1-deployment.yaml
+++ b/charts/tidepool/charts/clinic-worker/templates/1-deployment.yaml
@@ -145,11 +145,6 @@ spec:
               optional: true
         - name: TIDEPOOL_EXPORT_CLIENT_ADDRESS
           value: "http://export:{{.Values.global.ports.export}}"
-        - name: TIDEPOOL_DATA_SERVICE_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: data
-              key: ServiceAuth
         - name: EMAIL_REMINDERS_INTERVAL
           valueFrom:
             configMapKeyRef:

--- a/charts/tidepool/charts/clinic/templates/5-patient-deletions-source-kafka-connector.yaml
+++ b/charts/tidepool/charts/clinic/templates/5-patient-deletions-source-kafka-connector.yaml
@@ -1,0 +1,26 @@
+{{ if .Values.global.kafka.connect.enabled }}
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnector
+metadata:
+  labels:
+    app: patient-deletions-source
+    strimzi.io/cluster: {{ .Release.Namespace }}-{{ .Values.global.kafka.connect.clusterName }}
+  name: patient-deletions-source
+  namespace: {{ .Release.Namespace }}
+spec:
+  class: com.mongodb.kafka.connect.MongoSourceConnector
+  config:
+    change.stream.full.document: updateLookup
+    collection: patient_deletions
+    connection.uri: {{ .Values.global.kafka.connect.mongoConnectionUri }}
+    copy.existing: false
+    database: clinic
+    key.converter: org.apache.kafka.connect.json.JsonConverter
+    key.converter.schemas.enable: false
+    topic.prefix: {{ .Release.Namespace }}
+    value.converter: org.apache.kafka.connect.json.JsonConverter
+    value.converter.schemas.enable: false
+    heartbeat.interval.ms: {{ .Values.global.kafka.connect.mongoHeartbeatIntervalMs }}
+    heartbeat.topic.name: {{ .Release.Namespace }}-{{ .Values.global.kafka.connect.clusterName }}-heartbeat
+  tasksMax: {{ .Values.global.kafka.connect.sourceTasksMax | int }}
+{{- end }}


### PR DESCRIPTION
Used by clinic-worker to respond to patient deletions and then decide whether to delete the shoreline user.