### PR TITLE
allow setting Kafka JVM memory usage

### DIFF
--- a/charts/tidepool/Chart.yaml
+++ b/charts/tidepool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tidepool
 name: tidepool
-version: 0.25.0
+version: 0.25.1
 maintainers:
   - name: Todd Kazakov
     email: todd@tidepool.org

--- a/charts/tidepool/charts/kafka/templates/1-kafka-connect-mongo-cluster.yaml
+++ b/charts/tidepool/charts/kafka/templates/1-kafka-connect-mongo-cluster.yaml
@@ -51,6 +51,10 @@ spec:
           secretName: {{ .Values.keycloak.secretName }}
 {{- end }}
   image: {{ .Values.connect.image | quote }}
+{{- with .Values.connect.jvmOptions }}
+  jvmOptions:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   replicas: {{ .Values.global.kafka.connect.replicas | int }}
   resources:
     {{- toYaml .Values.resources | nindent 10 }}


### PR DESCRIPTION
This is needed by tiltronic to prevent the Kafka connect pods from
using defaults. The defaults have a bug on some Linux kernel versions
causing them to request tens of gigabytes of memory, which can then
cause the Kafka connect pods to be OOM-killed.